### PR TITLE
[frontend] fix(integrations-lib): renaming the filter key Type to Integration type

### DIFF
--- a/apps/portal-front/messages/en.json
+++ b/apps/portal-front/messages/en.json
@@ -525,8 +525,8 @@
           "Placeholder": "Subtype..."
         },
         "Type": {
-          "Label": "Type",
-          "Placeholder": "Type..."
+          "Label": "Integration type",
+          "Placeholder": "Integration type..."
         },
         "ProductVersion": {
           "Label": "Registered platforms",

--- a/apps/portal-front/messages/fr.json
+++ b/apps/portal-front/messages/fr.json
@@ -525,8 +525,8 @@
           "Placeholder": "Sous-type..."
         },
         "Type": {
-          "Label": "Type",
-          "Placeholder": "Type..."
+          "Label": "Type d'intégration",
+          "Placeholder": "Type d'intégration..."
         },
         "ProductVersion": {
           "Label": "Plateformes enregistrées",


### PR DESCRIPTION
# Context
> Renaming the filter key "Type..." to "Integration type..." for consistency according to the filter key "Deployment type..."
> 
<img width="1895" height="1077" alt="image" src="https://github.com/user-attachments/assets/4baf11e6-7814-4f96-9c5c-e38b6e7ceee2" />


## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

## Related issues

- #1618

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.