### PR TITLE
feat(integrations): handle integration with accordion and change lib title (#3133)

### DIFF
--- a/apps/e2e/tests/model/integration.pageModel.ts
+++ b/apps/e2e/tests/model/integration.pageModel.ts
@@ -62,6 +62,7 @@ export default class IntegrationPage {
     await selectSolutionCategories(this.page);
     await this.page.getByRole('radio', { name: 'Commercial' }).click();
     await this.page.getByRole('button', { name: 'Validate' }).click();
+    await this.page.getByText('TAXII Feeds').click();
   }
   async fillRssFeed({
     name,
@@ -92,6 +93,7 @@ export default class IntegrationPage {
     await selectSolutionCategories(this.page);
     await this.page.getByRole('radio', { name: 'Commercial' }).click();
     await this.page.getByRole('button', { name: 'Validate' }).click();
+    await this.page.getByText('RSS Feeds').click();
   }
 
   async fillStream({
@@ -125,6 +127,7 @@ export default class IntegrationPage {
     await selectSolutionCategories(this.page);
     await this.page.getByRole('radio', { name: 'Commercial' }).click();
     await this.page.getByRole('button', { name: 'Validate' }).click();
+    await this.page.getByText('OpenCTI Streams').click();
   }
   async fillCsvFeed({
     name,
@@ -155,6 +158,7 @@ export default class IntegrationPage {
     await selectSolutionCategories(this.page);
     await this.page.getByRole('radio', { name: 'Commercial' }).click();
     await this.page.getByRole('button', { name: 'Validate' }).click();
+    await this.page.getByText('CSV Feeds').click();
   }
 
   async fillThirdPartyIntegration({
@@ -200,6 +204,7 @@ export default class IntegrationPage {
     await selectSolutionCategories(this.page);
     await this.page.getByRole('radio', { name: 'Commercial' }).click();
     await this.page.getByRole('button', { name: 'Validate' }).click();
+    await this.page.getByText('Third Party integrations').click();
   }
 
   async navigateToIntegration(shortDescription: string) {
@@ -207,7 +212,16 @@ export default class IntegrationPage {
   }
 
   async deleteIntegration(deleteButtonRole: 'menuitem' | 'button') {
-    await this.page.getByRole(deleteButtonRole, { name: 'Delete' }).click();
-    await this.page.getByRole('button', { name: 'Delete' }).click();
+    if (deleteButtonRole === 'menuitem') {
+      const deleteAction = this.page
+        .getByRole('menu')
+        .first()
+        .getByRole('menuitem', { name: 'Delete' });
+      await deleteAction.click({ force: true });
+    } else {
+      await this.page.getByRole('button', { name: 'Delete' }).first().click();
+    }
+
+    await this.page.getByRole('button', { name: 'Delete' }).last().click();
   }
 }

--- a/apps/e2e/tests/tests_files/capabilities.spec.ts
+++ b/apps/e2e/tests/tests_files/capabilities.spec.ts
@@ -107,6 +107,7 @@ test.describe('Capabilities', () => {
     await test.step('Simple user can delete integration', async () => {
       await loginPage.navigateToAndLogin(TEST_CAPABILITY.userThalesEmail);
       await integrationPage.navigateToIntegrationsService();
+      await page.getByText('CSV Feeds').click();
 
       await page
         .getByRole('button', { name: 'Open menu', exact: true })

--- a/apps/frontend/src/components/epic/EpicList.tsx
+++ b/apps/frontend/src/components/epic/EpicList.tsx
@@ -2,13 +2,13 @@
 import { EpicFilter, EpicFilterType } from '@/components/epic/EpicFilter';
 import { EpicFormSheet } from '@/components/epic/EpicFormSheet';
 import { EpicItem } from '@/components/epic/epic-item/EpicItem';
-import { TimelineCountBadge } from '@/components/epic/epic-item/TimelineCountBadge';
 import { FiligranTimelineMapping } from '@/components/epic/epic-item/TimelineMapping';
 import {
   useCountEpicsByProduct,
   useDraftAndTimelineEpics,
 } from '@/components/epic/epic-list-utils';
 import { PortalContext } from '@/components/me/AppPortalContext';
+import { CountBadge } from '@/components/ui/CountBadge';
 import { useAdminByPass } from '@/hooks/use-portal-capability';
 import useServiceCapability from '@/hooks/use-service-capability';
 import { cn } from '@/lib/utils';
@@ -188,7 +188,7 @@ export const EpicList = ({
             key={timeline.title}
             className="flex items-stretch gap-m">
             <div className="flex flex-col items-center self-stretch mt-xl">
-              <TimelineCountBadge
+              <CountBadge
                 count={timeline.epics.length}
                 bgFadedClass={timelineMetadata.bgFadedClass}
                 textClass={timelineMetadata.textClass}

--- a/apps/frontend/src/components/homepage/roadmap/XtmRoadmap.tsx
+++ b/apps/frontend/src/components/homepage/roadmap/XtmRoadmap.tsx
@@ -1,9 +1,9 @@
-import { TimelineCountBadge } from '@/components/epic/epic-item/TimelineCountBadge';
 import {
   FiligranTimelineMapping,
   type FiligranTimelineMetadata,
 } from '@/components/epic/epic-item/TimelineMapping';
 import type { HomepageRoadmapTitleProduct } from '@/components/homepage/Homepage.utils';
+import { CountBadge } from '@/components/ui/CountBadge';
 import { PublicLocale } from '@/i18n/config';
 import { serverGraphqlFetch } from '@/lib/server-graphql-fetch';
 import { PUBLIC_CYBERSECURITY_SOLUTIONS_PATH } from '@/utils/path/constant';
@@ -98,7 +98,7 @@ const XtmRoadmap = async ({
               key={labelKey}
               className="flex flex-col gap-xs max-sm:gap-[2px]">
               <div className="flex items-center gap-s max-md:gap-xs max-sm:gap-[4px] pr-8 max-md:pr-5 max-sm:pr-1">
-                <TimelineCountBadge
+                <CountBadge
                   count={count}
                   bgFadedClass={bgFadedClass}
                   textClass={textClass}

--- a/apps/frontend/src/components/service/components/DocumentList.test.tsx
+++ b/apps/frontend/src/components/service/components/DocumentList.test.tsx
@@ -1,0 +1,61 @@
+import testRender from '@/utils/test/test-render';
+import { documentItem_fragment$data } from '@generated/documentItem_fragment.graphql';
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import DocumentList from './DocumentList';
+
+vi.mock('@/components/service/components/ServiceContext', () => ({
+  useServiceContext: () => ({
+    translationKey: 'Service.Connector',
+    serviceInstance: {
+      id: 'service-instance-1',
+      slug: 'my-service',
+      service_definition: {
+        identifier: 'opencti',
+      },
+    },
+    setIntegrationType: vi.fn(),
+  }),
+}));
+
+describe('DocumentList', () => {
+  it('renders one service card per document with expected URLs', () => {
+    const documents = [
+      {
+        id: 'doc-1',
+        slug: 'first-document',
+        name: 'First document',
+        type: 'opencti_integration',
+        short_description: 'Description 1',
+        use_cases: [],
+      },
+      {
+        id: 'doc-2',
+        slug: 'second-document',
+        name: 'Second document',
+        type: 'opencti_integration',
+        short_description: 'Description 2',
+        use_cases: [],
+      },
+    ] as documentItem_fragment$data[];
+
+    testRender(<DocumentList documents={documents} />);
+
+    expect(screen.getByText('First document')).toBeInTheDocument();
+    expect(screen.getByText('Second document')).toBeInTheDocument();
+
+    const detailLinks = screen
+      .getAllByRole('link')
+      .filter((link) => link.getAttribute('href')?.startsWith('/app/service/'));
+
+    expect(detailLinks).toHaveLength(2);
+    expect(detailLinks[0]).toHaveAttribute(
+      'href',
+      '/app/service/opencti/service-instance-1/doc-1'
+    );
+    expect(detailLinks[1]).toHaveAttribute(
+      'href',
+      '/app/service/opencti/service-instance-1/doc-2'
+    );
+  });
+});

--- a/apps/frontend/src/components/service/components/DocumentList.tsx
+++ b/apps/frontend/src/components/service/components/DocumentList.tsx
@@ -1,0 +1,36 @@
+import ServiceCard from '@/components/service/components/ServiceCard';
+import { useServiceContext } from '@/components/service/components/ServiceContext';
+import { SettingsContext } from '@/components/settings/EnvPortalContext';
+import {
+  APP_PATH,
+  PUBLIC_CYBERSECURITY_SOLUTIONS_PATH,
+} from '@/utils/path/constant';
+import { documentItem_fragment$data } from '@generated/documentItem_fragment.graphql';
+import { useContext } from 'react';
+
+interface DocumentListProps {
+  documents: documentItem_fragment$data[];
+}
+
+const DocumentList = ({ documents }: DocumentListProps) => {
+  const { settings } = useContext(SettingsContext);
+  const { serviceInstance } = useServiceContext();
+
+  return (
+    <ul
+      className={
+        'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-l'
+      }>
+      {documents.map((document) => (
+        <ServiceCard
+          key={document.id}
+          document={document}
+          detailUrl={`/${APP_PATH}/service/${serviceInstance.service_definition?.identifier}/${serviceInstance.id}/${document.id}`}
+          shareLinkUrl={`${settings!.base_url_front}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${document.slug}`}
+        />
+      ))}
+    </ul>
+  );
+};
+
+export default DocumentList;

--- a/apps/frontend/src/components/service/components/ServiceList.tsx
+++ b/apps/frontend/src/components/service/components/ServiceList.tsx
@@ -1,7 +1,4 @@
-import {
-  APP_PATH,
-  PUBLIC_CYBERSECURITY_SOLUTIONS_PATH,
-} from '@/utils/path/constant';
+import IntegrationAccordion from '@/components/ui/shareable-resource/IntegrationAccordion';
 import {
   IntegrationType,
   PortalCapability,
@@ -16,28 +13,19 @@ import {
   ServiceListHeader,
 } from '@/components/service/components/header/ServiceListHeader';
 import ServiceListHeaderButtons from '@/components/service/components/header/ServiceListHeaderButtons';
-import ServiceCard from '@/components/service/components/ServiceCard';
 import { useServiceContext } from '@/components/service/components/ServiceContext';
 import { useServiceListLocalStorageKeyContext } from '@/components/service/components/ServiceListLocalStorageKeyContext';
 import {
   getHeroSectionLibraryProps,
   HeroSectionLibrary,
 } from '@/components/service/document/ui/HeroSectionLibrary';
-import { SettingsContext } from '@/components/settings/EnvPortalContext';
-import { CountBadge } from '@/components/ui/CountBadge';
 import { useUserHasPortalCapability } from '@/hooks/use-portal-capability';
 import useScrollPosition from '@/hooks/use-scroll-position';
 import useServiceCapability from '@/hooks/use-service-capability';
 import { useServiceListLocalStorage } from '@/hooks/use-service-list-local-storage';
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from '@filigran/ui';
 import { documentItem_fragment$data } from '@generated/documentItem_fragment.graphql';
 import { useTranslations } from 'next-intl';
-import { Fragment, useContext, useLayoutEffect } from 'react';
+import { useLayoutEffect } from 'react';
 
 export interface ServiceListProps {
   active: documentItem_fragment$data[];
@@ -48,17 +36,17 @@ export interface ServiceListProps {
   connectionId?: string;
   paginationControls?: React.ReactNode;
 }
+
 const ServiceList = ({
   active,
   draft,
   search,
   onSearchChange,
   additionalFilters,
-  connectionId,
+  connectionId: _connectionId,
   paginationControls,
 }: ServiceListProps) => {
   const t = useTranslations();
-  const { settings } = useContext(SettingsContext);
   const { translationKey, serviceInstance, type } = useServiceContext();
   const userCanUpdate = useServiceCapability(
     ServiceRestriction.Upload,
@@ -119,20 +107,7 @@ const ServiceList = ({
           <div className="txt-category">
             {t(`${translationKey}.NonActive`)}:
           </div>
-          <ul
-            className={
-              'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-l'
-            }>
-            {draft.map((document) => (
-              <ServiceCard
-                key={document.id}
-                document={document}
-                connectionId={connectionId}
-                detailUrl={`/${APP_PATH}/service/${serviceInstance.service_definition?.identifier}/${serviceInstance.id}/${document.id}`}
-                shareLinkUrl={`${settings!.base_url_front}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${document.slug}`}
-              />
-            ))}
-          </ul>
+          <DocumentList documents={draft} />
           {active.length > 0 && (
             <div className="txt-category">{t(`${translationKey}.Active`)}:</div>
           )}
@@ -140,42 +115,22 @@ const ServiceList = ({
       )}
 
       {Object.entries(activeByIntegrationType).map(
-        ([integrationType, documents]) => (
-          <Fragment key={integrationType}>
-            {Object.values(IntegrationType).includes(
-              integrationType as IntegrationType
-            ) ? (
-              <Accordion
-                type="single"
-                collapsible>
-                <AccordionItem value={integrationType}>
-                  <h2 className="m-0">
-                    <AccordionTrigger className="hover:cursor-pointer">
-                      <div className="inline-flex items-center gap-s">
-                        {t(
-                          `Service.OpenctiIntegrations.Type.${integrationType}`
-                        )}
-                        <CountBadge
-                          count={documents.length}
-                          bgFadedClass={
-                            'bg-feedback-neutral-secondary-transparency'
-                          }
-                          textClass={'text-feedback-neutral-primary'}
-                        />
-                      </div>
-                    </AccordionTrigger>
-                  </h2>
-
-                  <AccordionContent>
-                    <DocumentList documents={documents} />
-                  </AccordionContent>
-                </AccordionItem>
-              </Accordion>
-            ) : (
+        ([integrationType, documents]) =>
+          Object.values(IntegrationType).includes(
+            integrationType as IntegrationType
+          ) ? (
+            <IntegrationAccordion
+              key={integrationType}
+              integrationType={integrationType}
+              count={documents.length}>
               <DocumentList documents={documents} />
-            )}
-          </Fragment>
-        )
+            </IntegrationAccordion>
+          ) : (
+            <DocumentList
+              key={integrationType}
+              documents={documents}
+            />
+          )
       )}
     </div>
   );

--- a/apps/frontend/src/components/service/components/ServiceList.tsx
+++ b/apps/frontend/src/components/service/components/ServiceList.tsx
@@ -8,6 +8,7 @@ import {
   ServiceRestriction,
 } from '@graphql/generated';
 
+import DocumentList from '@/components/service/components/DocumentList';
 import { ServiceListFilterLabel } from '@/components/service/components/header/filter/ServiceListFilterLabel';
 import {
   ServiceListFilterKey,
@@ -23,10 +24,17 @@ import {
   HeroSectionLibrary,
 } from '@/components/service/document/ui/HeroSectionLibrary';
 import { SettingsContext } from '@/components/settings/EnvPortalContext';
+import { CountBadge } from '@/components/ui/CountBadge';
 import { useUserHasPortalCapability } from '@/hooks/use-portal-capability';
 import useScrollPosition from '@/hooks/use-scroll-position';
 import useServiceCapability from '@/hooks/use-service-capability';
 import { useServiceListLocalStorage } from '@/hooks/use-service-list-local-storage';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@filigran/ui';
 import { documentItem_fragment$data } from '@generated/documentItem_fragment.graphql';
 import { useTranslations } from 'next-intl';
 import { Fragment, useContext, useLayoutEffect } from 'react';
@@ -136,24 +144,36 @@ const ServiceList = ({
           <Fragment key={integrationType}>
             {Object.values(IntegrationType).includes(
               integrationType as IntegrationType
-            ) && (
-              <h2>
-                {t(`Service.OpenctiIntegrations.Type.${integrationType}`)}
-              </h2>
+            ) ? (
+              <Accordion
+                type="single"
+                collapsible>
+                <AccordionItem value={integrationType}>
+                  <h2 className="m-0">
+                    <AccordionTrigger className="hover:cursor-pointer">
+                      <div className="inline-flex items-center gap-s">
+                        {t(
+                          `Service.OpenctiIntegrations.Type.${integrationType}`
+                        )}
+                        <CountBadge
+                          count={documents.length}
+                          bgFadedClass={
+                            'bg-feedback-neutral-secondary-transparency'
+                          }
+                          textClass={'text-feedback-neutral-primary'}
+                        />
+                      </div>
+                    </AccordionTrigger>
+                  </h2>
+
+                  <AccordionContent>
+                    <DocumentList documents={documents} />
+                  </AccordionContent>
+                </AccordionItem>
+              </Accordion>
+            ) : (
+              <DocumentList documents={documents} />
             )}
-            <ul
-              className={
-                'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-l'
-              }>
-              {documents.map((document) => (
-                <ServiceCard
-                  key={document.id}
-                  document={document}
-                  detailUrl={`/${APP_PATH}/service/${serviceInstance.service_definition?.identifier}/${serviceInstance.id}/${document.id}`}
-                  shareLinkUrl={`${settings!.base_url_front}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${document.slug}`}
-                />
-              ))}
-            </ul>
           </Fragment>
         )
       )}

--- a/apps/frontend/src/components/service/document/ui/HeroSectionLibrary.tsx
+++ b/apps/frontend/src/components/service/document/ui/HeroSectionLibrary.tsx
@@ -38,19 +38,18 @@ export const HeroSectionLibrary = ({
   showLibraryUpdate = false,
 }: HeroSectionLibraryProps) => {
   return (
-    <section className="px-m pt-m pb-xxl text-center">
+    <section className="px-m pt-m pb-xxl">
       <div className="flex flex-col gap-s">
         <p className="text-primary font-bold">{eyebrow}</p>
-        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-s">
-          <div />
+        <div className="flex flex-row items-center">
           <h1 className="heading-2xl">{name}</h1>
           {showLibraryUpdate && (
-            <div className="justify-self-start">
+            <div className="flex items-center">
               <LibraryUpdateMetadata />
             </div>
           )}
         </div>
-        <div className="flex items-center justify-center gap-s">
+        <div className="flex gap-s">
           <p className="max-w-lg txt-sub-content">{description}</p>
         </div>
       </div>

--- a/apps/frontend/src/components/service/document/ui/HeroSectionLibrary.tsx
+++ b/apps/frontend/src/components/service/document/ui/HeroSectionLibrary.tsx
@@ -38,7 +38,7 @@ export const HeroSectionLibrary = ({
   showLibraryUpdate = false,
 }: HeroSectionLibraryProps) => {
   return (
-    <section className="px-m pt-m pb-xxl">
+    <section className="pt-m pb-xxl">
       <div className="flex flex-col gap-s">
         <p className="text-primary font-bold">{eyebrow}</p>
         <div className="flex flex-row items-center">

--- a/apps/frontend/src/components/ui/CountBadge.test.tsx
+++ b/apps/frontend/src/components/ui/CountBadge.test.tsx
@@ -1,13 +1,13 @@
-import { TimelineCountBadge } from '@/components/epic/epic-item/TimelineCountBadge';
 import testRender from '@/utils/test/test-render';
 import { screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
+import { CountBadge } from './CountBadge';
 
-describe('TimelineCountBadge', () => {
+describe('CountBadge', () => {
   it('renders count and applies timeline classes', () => {
     // Given
     const { container } = testRender(
-      <TimelineCountBadge
+      <CountBadge
         count={7}
         bgFadedClass="bg-feedback-info-faded"
         textClass="text-feedback-info-primary"

--- a/apps/frontend/src/components/ui/CountBadge.tsx
+++ b/apps/frontend/src/components/ui/CountBadge.tsx
@@ -1,18 +1,18 @@
 import { cn } from '@/lib/utils';
 
-interface TimelineCountBadgeProps {
+interface CountBadgeProps {
   count: number;
   bgFadedClass: string;
   textClass: string;
   className?: string;
 }
 
-export const TimelineCountBadge = ({
+export const CountBadge = ({
   count,
   bgFadedClass,
   textClass,
   className,
-}: TimelineCountBadgeProps) => (
+}: CountBadgeProps) => (
   <div
     className={cn(
       'rounded-full w-6 h-6 flex items-center justify-center relative shrink-0',

--- a/apps/frontend/src/components/ui/shareable-resource/IntegrationAccordion.test.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/IntegrationAccordion.test.tsx
@@ -1,0 +1,48 @@
+import testRender from '@/utils/test/test-render';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import IntegrationAccordion from './IntegrationAccordion';
+
+describe('IntegrationAccordion', () => {
+  const integrationType = 'connector';
+  const count = 2;
+  const childrenText = 'accordion-child-content';
+  const triggerLabelPattern = new RegExp(
+    `Service\\.OpenctiIntegrations\\.Type\\.${integrationType}`
+  );
+
+  it('should display the accordion label and count when rendered', () => {
+    // Given
+    // When
+    testRender(
+      <IntegrationAccordion
+        integrationType={integrationType}
+        count={count}>
+        <div>{childrenText}</div>
+      </IntegrationAccordion>
+    );
+
+    // Then
+    expect(
+      screen.getByRole('button', { name: triggerLabelPattern })
+    ).toBeInTheDocument();
+    expect(screen.getByText(String(count))).toBeInTheDocument();
+  });
+
+  it('should display the children when the accordion is opened', async () => {
+    // Given
+    const { user } = testRender(
+      <IntegrationAccordion
+        integrationType={integrationType}
+        count={count}>
+        <div>{childrenText}</div>
+      </IntegrationAccordion>
+    );
+
+    // When
+    await user.click(screen.getByRole('button', { name: triggerLabelPattern }));
+
+    // Then
+    expect(screen.getByText(childrenText)).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/ui/shareable-resource/IntegrationAccordion.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/IntegrationAccordion.tsx
@@ -1,0 +1,48 @@
+import { CountBadge } from '@/components/ui/CountBadge';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@filigran/ui';
+import { useTranslations } from 'next-intl';
+import React from 'react';
+
+interface IntegrationAccordionProps {
+  integrationType: string;
+  count: number;
+  children: React.ReactNode;
+}
+
+const IntegrationAccordion = ({
+  integrationType,
+  count,
+  children,
+}: IntegrationAccordionProps) => {
+  const t = useTranslations();
+
+  return (
+    <Accordion
+      type="single"
+      collapsible>
+      <AccordionItem value={integrationType}>
+        <h2 className="m-0">
+          <AccordionTrigger className="hover:cursor-pointer">
+            <div className="inline-flex items-center gap-s">
+              {t(`Service.OpenctiIntegrations.Type.${integrationType}`)}
+              <CountBadge
+                count={count}
+                bgFadedClass={'bg-feedback-neutral-secondary-transparency'}
+                textClass={'text-feedback-neutral-primary'}
+              />
+            </div>
+          </AccordionTrigger>
+        </h2>
+
+        <AccordionContent>{children}</AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+};
+
+export default IntegrationAccordion;

--- a/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.test.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.test.tsx
@@ -1,0 +1,60 @@
+import testRender from '@/utils/test/test-render';
+import { publicDocumentListItemFragment$data } from '@generated/publicDocumentListItemFragment.graphql';
+import { seoServiceInstanceFragment$data } from '@generated/seoServiceInstanceFragment.graphql';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { PublicShareableDocumentList } from './PublicShareableDocumentList';
+
+describe('PublicShareableDocumentList', () => {
+  it('renders one public card per document with expected public URLs', () => {
+    const serviceInstance = {
+      id: 'service-1',
+      slug: 'my-service',
+    } as seoServiceInstanceFragment$data;
+    const documents = [
+      {
+        id: 'doc-1',
+        slug: 'connector-doc',
+        name: 'Connector document',
+        type: 'opencti_custom_dashboard',
+        short_description: 'Connector description',
+        use_cases: [],
+      },
+      {
+        id: 'doc-2',
+        slug: 'dashboard-doc',
+        name: 'Dashboard document',
+        type: 'opencti_custom_dashboard',
+        short_description: 'Dashboard description',
+        use_cases: [],
+      },
+    ] as publicDocumentListItemFragment$data[];
+
+    testRender(
+      <PublicShareableDocumentList
+        documents={documents}
+        serviceInstance={serviceInstance}
+        baseUrl="https://xtm.local"
+      />
+    );
+
+    expect(screen.getByText('Connector document')).toBeInTheDocument();
+    expect(screen.getByText('Dashboard document')).toBeInTheDocument();
+
+    const detailLinks = screen
+      .getAllByRole('link')
+      .filter((link) =>
+        link.getAttribute('href')?.startsWith('/en/cybersecurity-solutions/')
+      );
+
+    expect(detailLinks).toHaveLength(2);
+    expect(detailLinks[0]).toHaveAttribute(
+      'href',
+      '/en/cybersecurity-solutions/my-service/connector-doc'
+    );
+    expect(detailLinks[1]).toHaveAttribute(
+      'href',
+      '/en/cybersecurity-solutions/my-service/dashboard-doc'
+    );
+  });
+});

--- a/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.tsx
@@ -1,0 +1,37 @@
+import ShareableResourceCard from '@/components/ui/shareable-resource/ShareableResourceCard';
+import { PUBLIC_CYBERSECURITY_SOLUTIONS_PATH } from '@/utils/path/constant';
+import { publicDocumentListItemFragment$data } from '@generated/publicDocumentListItemFragment.graphql';
+import { seoServiceInstanceFragment$data } from '@generated/seoServiceInstanceFragment.graphql';
+import { useLocale } from 'next-intl';
+
+interface PublicShareableDocumentListProps {
+  documents: publicDocumentListItemFragment$data[];
+  serviceInstance: seoServiceInstanceFragment$data;
+  baseUrl: string;
+}
+
+export const PublicShareableDocumentList = ({
+  documents,
+  serviceInstance,
+  baseUrl,
+}: PublicShareableDocumentListProps) => {
+  const locale = useLocale();
+
+  return (
+    <ul
+      className={
+        'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-l'
+      }>
+      {documents.map((document) => (
+        <ShareableResourceCard
+          publicPath
+          key={document.id}
+          document={document}
+          serviceInstance={serviceInstance}
+          detailUrl={`/${locale}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${document.slug}`}
+          shareLinkUrl={`${baseUrl}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${document.slug}`}
+        />
+      ))}
+    </ul>
+  );
+};

--- a/apps/frontend/src/components/ui/shareable-resource/PublicShareableResourceList.test.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/PublicShareableResourceList.test.tsx
@@ -29,7 +29,7 @@ describe('PublicShareableResourceList', () => {
     expect(screen.getByText('Utils.DocumentNotFound')).toBeInTheDocument();
   });
 
-  it('groups integrations by integration_type and renders document names with correct links', () => {
+  it('groups integrations by integration_type and renders document names with correct links', async () => {
     const documents = [
       {
         id: 'doc-1',
@@ -47,7 +47,7 @@ describe('PublicShareableResourceList', () => {
       },
     ];
 
-    testRender(
+    const { user } = testRender(
       <PublicShareableResourceList
         documents={documents as publicDocumentListItemFragment$data[]}
         serviceInstance={serviceInstance as seoServiceInstanceFragment$data}
@@ -60,8 +60,16 @@ describe('PublicShareableResourceList', () => {
         `Service.OpenctiIntegrations.Type.${IntegrationType.Connector}`
       )
     ).toBeInTheDocument();
-    expect(screen.getByText('My Connector')).toBeInTheDocument();
     expect(screen.getByText('My Dashboard')).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', {
+        name: new RegExp(
+          `Service\\.OpenctiIntegrations\\.Type\\.${IntegrationType.Connector}`
+        ),
+      })
+    );
+    expect(screen.getByText('My Connector')).toBeInTheDocument();
 
     const links = screen.getAllByRole('link');
     const connectorLink = links.find((l) =>

--- a/apps/frontend/src/components/ui/shareable-resource/PublicShareableResourceList.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/PublicShareableResourceList.tsx
@@ -1,12 +1,6 @@
-import { CountBadge } from '@/components/ui/CountBadge';
+import IntegrationAccordion from '@/components/ui/shareable-resource/IntegrationAccordion';
 import { PublicShareableDocumentList } from '@/components/ui/shareable-resource/PublicShareableDocumentList';
 import { isIntegrationItem } from '@/utils/shareable-resources/shareable-resources.types';
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from '@filigran/ui';
 import { publicDocumentListItemFragment$data } from '@generated/publicDocumentListItemFragment.graphql';
 import { seoServiceInstanceFragment$data } from '@generated/seoServiceInstanceFragment.graphql';
 import { IntegrationType } from '@graphql/generated';
@@ -58,36 +52,16 @@ export const PublicShareableResourceList = ({
             {Object.values(IntegrationType).includes(
               integrationType as IntegrationType
             ) ? (
-              <Accordion
-                type="single"
-                collapsible>
-                <AccordionItem value={integrationType}>
-                  <h2 className="m-0">
-                    <AccordionTrigger className="hover:cursor-pointer">
-                      <div className="inline-flex items-center gap-s">
-                        {t(
-                          `Service.OpenctiIntegrations.Type.${integrationType}`
-                        )}
-                        <CountBadge
-                          count={documents.length}
-                          bgFadedClass={
-                            'bg-feedback-neutral-secondary-transparency'
-                          }
-                          textClass={'text-feedback-neutral-primary'}
-                        />
-                      </div>
-                    </AccordionTrigger>
-                  </h2>
-
-                  <AccordionContent>
-                    <PublicShareableDocumentList
-                      documents={documents}
-                      serviceInstance={serviceInstance}
-                      baseUrl={baseUrl}
-                    />
-                  </AccordionContent>
-                </AccordionItem>
-              </Accordion>
+              <IntegrationAccordion
+                key={integrationType}
+                integrationType={integrationType}
+                count={documents.length}>
+                <PublicShareableDocumentList
+                  documents={documents}
+                  serviceInstance={serviceInstance}
+                  baseUrl={baseUrl}
+                />
+              </IntegrationAccordion>
             ) : (
               <PublicShareableDocumentList
                 documents={documents}

--- a/apps/frontend/src/components/ui/shareable-resource/PublicShareableResourceList.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/PublicShareableResourceList.tsx
@@ -1,10 +1,16 @@
-import ShareableResourceCard from '@/components/ui/shareable-resource/ShareableResourceCard';
-import { PUBLIC_CYBERSECURITY_SOLUTIONS_PATH } from '@/utils/path/constant';
+import { CountBadge } from '@/components/ui/CountBadge';
+import { PublicShareableDocumentList } from '@/components/ui/shareable-resource/PublicShareableDocumentList';
 import { isIntegrationItem } from '@/utils/shareable-resources/shareable-resources.types';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@filigran/ui';
 import { publicDocumentListItemFragment$data } from '@generated/publicDocumentListItemFragment.graphql';
 import { seoServiceInstanceFragment$data } from '@generated/seoServiceInstanceFragment.graphql';
 import { IntegrationType } from '@graphql/generated';
-import { useLocale, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 import { Fragment, useMemo } from 'react';
 
 interface PublicShareableResourceListProps {
@@ -19,7 +25,6 @@ export const PublicShareableResourceList = ({
   baseUrl,
 }: PublicShareableResourceListProps) => {
   const t = useTranslations();
-  const locale = useLocale();
 
   const documentsByIntegrationType = useMemo(() => {
     return documents.reduce<
@@ -52,26 +57,44 @@ export const PublicShareableResourceList = ({
           <Fragment key={integrationType}>
             {Object.values(IntegrationType).includes(
               integrationType as IntegrationType
-            ) && (
-              <h2 className="mt-xl">
-                {t(`Service.OpenctiIntegrations.Type.${integrationType}`)}
-              </h2>
+            ) ? (
+              <Accordion
+                type="single"
+                collapsible>
+                <AccordionItem value={integrationType}>
+                  <h2 className="m-0">
+                    <AccordionTrigger className="hover:cursor-pointer">
+                      <div className="inline-flex items-center gap-s">
+                        {t(
+                          `Service.OpenctiIntegrations.Type.${integrationType}`
+                        )}
+                        <CountBadge
+                          count={documents.length}
+                          bgFadedClass={
+                            'bg-feedback-neutral-secondary-transparency'
+                          }
+                          textClass={'text-feedback-neutral-primary'}
+                        />
+                      </div>
+                    </AccordionTrigger>
+                  </h2>
+
+                  <AccordionContent>
+                    <PublicShareableDocumentList
+                      documents={documents}
+                      serviceInstance={serviceInstance}
+                      baseUrl={baseUrl}
+                    />
+                  </AccordionContent>
+                </AccordionItem>
+              </Accordion>
+            ) : (
+              <PublicShareableDocumentList
+                documents={documents}
+                serviceInstance={serviceInstance}
+                baseUrl={baseUrl}
+              />
             )}
-            <ul
-              className={
-                'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-l'
-              }>
-              {documents.map((document) => (
-                <ShareableResourceCard
-                  publicPath
-                  key={document.id}
-                  document={document}
-                  serviceInstance={serviceInstance}
-                  detailUrl={`/${locale}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${document.slug}`}
-                  shareLinkUrl={`${baseUrl}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${document.slug}`}
-                />
-              ))}
-            </ul>
           </Fragment>
         )
       )}


### PR DESCRIPTION
# Context
> Adapt the libraries header to stick left 
> Adapt the integration library component to have accordions between integrations. 

## How to test
- Stay on public pages. All libraries should have title on the left. 
- Integration libraries should be separated in accordions. 
- Login. 
- All libraries should have title on the left. 
- Integration libraries should be separated in accordions. 

https://github.com/user-attachments/assets/4aae3770-fc18-41e2-94d2-0bcc9f106337

## Related issues

- Related to #3133

# Checklist

## Quality

- [X] I consider this work complete and ready for review
- [X] I tested all features and edge cases
- [X] I refactored code where necessary to improve quality
- [X] I made sure my code meets development guidelines
- [X] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [X] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [X] Local manual tests
