### PR TITLE
feat(chart): Gateway API migration mode

### DIFF
--- a/chart/templates/barman-object-store.yaml
+++ b/chart/templates/barman-object-store.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.postgres.backup.enabled }}
+{{- $objectStoreName := printf "%s-barman-objectstore" .Release.Name }}
 {{- $existing := (lookup "barmancloud.cnpg.io/v1" "ObjectStore" .Release.Namespace $objectStoreName) }}
 {{- $defaultPath := printf "s3://%s/backup-%s" .Values.postgres.backup.s3BucketName (now | date "20060102T150405") }}
 {{- $destinationPath := dig "spec" "configuration" "destinationPath" $defaultPath $existing }}

--- a/chart/templates/gateway.yaml
+++ b/chart/templates/gateway.yaml
@@ -1,0 +1,139 @@
+{{- if has .Values.gatewayApi.mode (list "dual" "cutover" "only") }}
+{{- $host := tpl .Values.xtmhub.host . }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: {{ .Release.Namespace }}-{{ .Release.Name }}-listeners
+spec:
+  parentRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ .Values.gatewayApi.pool.name }}
+    namespace: {{ .Values.gatewayApi.pool.namespace }}
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: {{ $host }}
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: xtmhub-cert
+        {{- if .Values.gatewayApi.minTlsVersion }}
+        options:
+          kgateway.dev/min-tls-version: {{ .Values.gatewayApi.minTlsVersion | quote }}
+        {{- end }}
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+{{- if eq .Values.gatewayApi.mode "only" }}
+# in dual/cutover the Ingress cert-manager shim maintains this secret; once the
+# Ingress is gone ("only"), this explicit Certificate takes over the same secret
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: xtmhub-cert
+spec:
+  secretName: xtmhub-cert
+  issuerRef:
+    name: {{ .Values.tls_issuer }}
+    kind: ClusterIssuer
+  dnsNames:
+    - {{ $host }}
+---
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Namespace }}-{{ .Release.Name }}-route
+  annotations:
+    # ListenerSet-parented routes are invisible to external-dns (it only resolves
+    # Gateway parents) — DNS rides the redirect route; keep this one out permanently
+    external-dns.alpha.kubernetes.io/controller: ignore
+    prometheus.io/probe: "true"
+spec:
+  hostnames:
+    - {{ $host }}
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: {{ .Release.Namespace }}-{{ .Release.Name }}-listeners
+      sectionName: https
+  rules:
+    # static assets cache headers (nginx configuration-snippet equivalent)
+    - matches:
+        - path:
+            type: RegularExpression
+            value: ".*\\.(js|css|gif|jpe?g|png|svg|ico)$"
+      filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Cache-Control
+                value: "public, max-age=2592000"
+      backendRefs:
+        - name: xtmhub-front
+          port: 3000
+    - backendRefs:
+        - name: xtmhub-front
+          port: 3000
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Namespace }}-{{ .Release.Name }}-redirect
+  annotations:
+    # the redirect route is the gateway-side DNS source: it is the only route
+    # external-dns can resolve an address from (Gateway parent). Ignored in dual
+    # so the nginx Ingress stays the single DNS owner until cutover.
+    {{- if eq .Values.gatewayApi.mode "dual" }}
+    external-dns.alpha.kubernetes.io/controller: ignore
+    {{- end }}
+    external-dns.alpha.kubernetes.io/ttl: "120"
+spec:
+  hostnames:
+    - {{ $host }}
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ .Values.gatewayApi.pool.name }}
+      namespace: {{ .Values.gatewayApi.pool.namespace }}
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: {{ .Release.Namespace }}-{{ .Release.Name }}-policy
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ .Release.Namespace }}-{{ .Release.Name }}-route
+  buffer:
+    maxRequestSize: 256Mi
+  retry:
+    attempts: 3
+    retryOn:
+      - connect-failure
+      - reset
+      - retriable-status-codes
+    statusCodes: [502, 503, 504]
+---
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: BackendConfigPolicy
+metadata:
+  name: {{ .Release.Namespace }}-{{ .Release.Name }}-backend
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: xtmhub-front
+  connectTimeout: 30s
+{{- end }}

--- a/chart/templates/gateway.yaml
+++ b/chart/templates/gateway.yaml
@@ -1,4 +1,10 @@
-{{- if has .Values.gatewayApi.mode (list "dual" "cutover" "only") }}
+{{- if has ((.Values.gatewayApi).mode | default "off") (list "dual" "cutover" "only") }}
+{{- if not (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1") }}
+{{- fail "gatewayApi.mode requires the Gateway API CRDs (gateway.networking.k8s.io/v1) on the target cluster" }}
+{{- end }}
+{{- if not (.Capabilities.APIVersions.Has "gateway.kgateway.dev/v1alpha1") }}
+{{- fail "gatewayApi.mode requires kgateway (gateway.kgateway.dev/v1alpha1) on the target cluster" }}
+{{- end }}
 {{- $host := tpl .Values.xtmhub.host . }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: ListenerSet
@@ -27,7 +33,7 @@ spec:
         namespaces:
           from: Same
 ---
-{{- if eq .Values.gatewayApi.mode "only" }}
+{{- if eq ((.Values.gatewayApi).mode | default "off") "only" }}
 # in dual/cutover the Ingress cert-manager shim maintains this secret; once the
 # Ingress is gone ("only"), this explicit Certificate takes over the same secret
 apiVersion: cert-manager.io/v1
@@ -87,7 +93,7 @@ metadata:
     # the redirect route is the gateway-side DNS source: it is the only route
     # external-dns can resolve an address from (Gateway parent). Ignored in dual
     # so the nginx Ingress stays the single DNS owner until cutover.
-    {{- if eq .Values.gatewayApi.mode "dual" }}
+    {{- if eq ((.Values.gatewayApi).mode | default "off") "dual" }}
     external-dns.alpha.kubernetes.io/controller: ignore
     {{- end }}
     external-dns.alpha.kubernetes.io/ttl: "120"

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,9 +1,14 @@
+{{- if ne .Values.gatewayApi.mode "only" }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Release.Namespace}}-{{ .Release.Name }}-ingress
   annotations:
     cert-manager.io/cluster-issuer: {{ .Values.tls_issuer }}
+    {{- if eq .Values.gatewayApi.mode "cutover" }}
+    # cutover: the gateway redirect route owns DNS, the Ingress must let go
+    external-dns.alpha.kubernetes.io/controller: ignore
+    {{- end }}
     external-dns.alpha.kubernetes.io/hostname: {{ tpl .Values.xtmhub.host . }}
     external-dns.alpha.kubernetes.io/ttl: "120"
     prometheus.io/probe: "true"
@@ -35,3 +40,4 @@ spec:
   - hosts:
     - {{ .Values.xtmhub.host }}
     secretName: xtmhub-cert
+{{- end }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,11 +1,11 @@
-{{- if ne .Values.gatewayApi.mode "only" }}
+{{- if ne ((.Values.gatewayApi).mode | default "off") "only" }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Release.Namespace}}-{{ .Release.Name }}-ingress
   annotations:
     cert-manager.io/cluster-issuer: {{ .Values.tls_issuer }}
-    {{- if eq .Values.gatewayApi.mode "cutover" }}
+    {{- if eq ((.Values.gatewayApi).mode | default "off") "cutover" }}
     # cutover: the gateway redirect route owns DNS, the Ingress must let go
     external-dns.alpha.kubernetes.io/controller: ignore
     {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,5 +1,16 @@
 tls_issuer: le-staging
 ingressClass: nginx
+# Gateway API migration state machine (platform#3074):
+#   off     -> nginx Ingress only (default, no gateway resources)
+#   dual    -> both paths live, DNS stays on nginx
+#   cutover -> both paths live, DNS moves to the gateway pool
+#   only    -> gateway only, the Ingress is removed
+gatewayApi:
+  mode: "off"
+  minTlsVersion: ""
+  pool:
+    name: gateway-pool
+    namespace: kgateway-system
 xtmhub:
   node_env: "production"
   api:


### PR DESCRIPTION
## Summary
Ports the Gateway API migration state machine to the xtmhub chart — same design as FiligranHQ/helm-opencti#355 and FiligranHQ/helm-openaev#166, tracked by FiligranHQ/platform#3074.

`gatewayApi.mode` drives the transition: `off` (default, renders identically to master) → `dual` (both paths live, DNS on nginx) → `cutover` (DNS moves to the gateway pool) → `only` (Ingress removed, an explicit Certificate takes over from the cert-manager Ingress shim).

Also fixes a pre-existing parse error on master (`$objectStoreName` used without declaration in barman-object-store.yaml — `helm template`/`upgrade` currently fail from this tree).

## Scope
Product base URL only (iteration 1): the front Ingress. Management ingresses (kibana/minio/pgadmin/elasticsearch — incl. the ES mTLS specifics) stay on nginx for iteration 2.

## Validation
- All four modes render-validated; `off` is byte-identical to master
- The DNS choreography (redirect route as the gateway-side carrier, handover annotation at cutover) is the exact pattern already validated live by three measured dev migrations (zero-gap DNS flips, 100% availability on both paths)

## Next
Dev validation on the `xtmhub` instance (dev.hub.dev.filigran.io) after review, following the same measured procedure (probe on both paths, server-side dry-run before each transition).