### PR TITLE
feat(libraries): serviceHeader sticky and toggle list/tab (#3134)

### DIFF
--- a/apps/e2e/tests/model/integration.pageModel.ts
+++ b/apps/e2e/tests/model/integration.pageModel.ts
@@ -213,15 +213,17 @@ export default class IntegrationPage {
 
   async deleteIntegration(deleteButtonRole: 'menuitem' | 'button') {
     if (deleteButtonRole === 'menuitem') {
-      const deleteAction = this.page
-        .getByRole('menu')
-        .first()
-        .getByRole('menuitem', { name: 'Delete' });
-      await deleteAction.click({ force: true });
+      await this.page
+        .getByRole('menuitem', { name: 'Delete' })
+        .last()
+        .click({ force: true });
     } else {
       await this.page.getByRole('button', { name: 'Delete' }).first().click();
     }
 
-    await this.page.getByRole('button', { name: 'Delete' }).last().click();
+    await this.page
+      .getByRole('alertdialog')
+      .getByRole('button', { name: 'Delete' })
+      .click();
   }
 }

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -1224,6 +1224,14 @@
     "List": {
       "ViewTab": "Select tab view",
       "ViewList": "Select list view",
+      "Tab": {
+        "Name": "Name",
+        "Description": "Description",
+        "UseCases": "Use cases",
+        "Actions": "Actions",
+        "Author": "Author",
+        "MinimumDeployableVersion": "Minimum deployable version"
+      },
       "Filter": {
         "Add": "Add filter",
         "NoOptions": "No options",

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -1222,6 +1222,8 @@
     "GoTo": "Go to service page",
     "GoToAdminLabel": "Manage",
     "List": {
+      "ViewTab": "Select tab view",
+      "ViewList": "Select list view",
       "Filter": {
         "Add": "Add filter",
         "NoOptions": "No options",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -202,9 +202,9 @@
       "CAN_UNREGISTER_PLATFORM_UNKNOWN_ERROR": "Une erreur inconnue s'est produite lors de la déconnexion du produit",
       "CANT_ADD_DISABLED_USER": "Vous ne pouvez pas ajouter un utilisateur qui est désactivé sur la plateforme",
       "CANT_ADD_USER_TO_PERSONAL_SPACE": "Vous ne pouvez pas ajouter un utilisateur à votre espace personnel",
+      "CANT_CANCEL_BUNDLE_PRODUCT": "Un produit d'un XTM Platform Trial ne peut pas être annulé seul",
       "CANT_DELETE_BUILTIN_USER": "Cet utilisateur intégré ne peut pas être supprimé",
       "CANT_DELETE_YOURSELF": "Vous ne pouvez pas supprimer votre propre compte",
-      "CANT_CANCEL_BUNDLE_PRODUCT": "Un produit d'un XTM Platform Trial ne peut pas être annulé seul",
       "CANT_REMOVE_LAST_ADMINISTRATOR": "Vous ne pouvez pas supprimer le dernier administrateur d'une organisation",
       "CANT_REMOVE_YOURSELF_FROM_ORGA_ERROR": "Vous ne pouvez pas vous retirer vous-même de l'organisation",
       "CANT_REQUEST_FREE_TRIAL": "Vous ne pouvez pas demander d'essai gratuit",
@@ -1222,6 +1222,8 @@
     "GoTo": "Aller au service",
     "GoToAdminLabel": "Administrer",
     "List": {
+      "ViewTab": "Sélectionner l'affichage par onglets",
+      "ViewList": "Sélectionner l'affichage sous forme de liste",
       "Filter": {
         "Add": "Ajouter un filtre",
         "NoOptions": "Pas d'options",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -1224,6 +1224,14 @@
     "List": {
       "ViewTab": "Sélectionner l'affichage par onglets",
       "ViewList": "Sélectionner l'affichage sous forme de liste",
+      "Tab": {
+        "Name": "Nom",
+        "Description": "Description",
+        "UseCases": "Cas d'utilisation",
+        "Actions": "Actions",
+        "Author": "Auteur",
+        "MinimumDeployableVersion": "Version minimale déployable"
+      },
       "Filter": {
         "Add": "Ajouter un filtre",
         "NoOptions": "Pas d'options",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -1224,6 +1224,14 @@
     "List": {
       "ViewTab": "タブ表示を選択",
       "ViewList": "リスト表示を選択",
+      "Tab": {
+        "Name": "名前",
+        "Description": "説明",
+        "UseCases": "ユースケース",
+        "Actions": "アクション",
+        "Author": "作成者",
+        "MinimumDeployableVersion": "デプロイ可能な最小バージョン"
+      },
       "Filter": {
         "Add": "フィルターの追加",
         "NoOptions": "オプションなし",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -202,9 +202,9 @@
       "CAN_UNREGISTER_PLATFORM_UNKNOWN_ERROR": "製品の切断中に不明なエラーが発生しました。",
       "CANT_ADD_DISABLED_USER": "プラットフォームで無効になっているユーザーを追加できない",
       "CANT_ADD_USER_TO_PERSONAL_SPACE": "パーソナルスペースにユーザーを追加することはできません",
+      "CANT_CANCEL_BUNDLE_PRODUCT": "XTM Platform Trial 内の個別の製品はキャンセルできない",
       "CANT_DELETE_BUILTIN_USER": "この組み込みユーザーは削除できません",
       "CANT_DELETE_YOURSELF": "自分のアカウントを削除することはできません",
-      "CANT_CANCEL_BUNDLE_PRODUCT": "XTM Platform Trial 内の個別の製品はキャンセルできない",
       "CANT_REMOVE_LAST_ADMINISTRATOR": "組織の最後の管理者を削除することはできない",
       "CANT_REMOVE_YOURSELF_FROM_ORGA_ERROR": "組織から自分自身を削除することはできない",
       "CANT_REQUEST_FREE_TRIAL": "無料トライアルのリクエストはできない",
@@ -1222,6 +1222,8 @@
     "GoTo": "サービスページへ",
     "GoToAdminLabel": "管理する",
     "List": {
+      "ViewTab": "タブ表示を選択",
+      "ViewList": "リスト表示を選択",
       "Filter": {
         "Add": "フィルターの追加",
         "NoOptions": "オプションなし",

--- a/apps/frontend/setup-vitest.ts
+++ b/apps/frontend/setup-vitest.ts
@@ -50,7 +50,10 @@ vi.mock('next/navigation', async (importOriginal) => ({
 
 vi.mock('next-intl', async (importOriginal) => ({
   ...(await importOriginal<typeof import('next-intl')>()),
-  useTranslations: vi.fn(() => (key: string) => key),
+  useTranslations: () =>
+    Object.assign((key: string) => key, {
+      has: () => false,
+    }),
   useLocale: vi.fn(() => 'en'),
 }));
 

--- a/apps/frontend/setup-vitest.ts
+++ b/apps/frontend/setup-vitest.ts
@@ -50,10 +50,11 @@ vi.mock('next/navigation', async (importOriginal) => ({
 
 vi.mock('next-intl', async (importOriginal) => ({
   ...(await importOriginal<typeof import('next-intl')>()),
-  useTranslations: () =>
+  useTranslations: vi.fn(() =>
     Object.assign((key: string) => key, {
       has: () => false,
-    }),
+    })
+  ),
   useLocale: vi.fn(() => 'en'),
 }));
 

--- a/apps/frontend/src/components/service/components/DocumentActionsCell.tsx
+++ b/apps/frontend/src/components/service/components/DocumentActionsCell.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useServiceContext } from '@/components/service/components/ServiceContext';
+import {
+  CardTypeEnum,
+  ServiceDelete,
+} from '@/components/service/components/ServiceDelete';
+import { ServiceManageSheet } from '@/components/service/components/ServiceManageSheet';
+import { useDocumentContext } from '@/components/service/document/use-document-context';
+import { SettingsContext } from '@/components/settings/EnvPortalContext';
+import { IconActions, IconActionsItem } from '@/components/ui/IconActions';
+import { ShareLinkButton } from '@/components/ui/share-link/ShareLinkButton';
+import useServiceCapability from '@/hooks/use-service-capability';
+import revalidatePathActions from '@/utils/actions/revalidate-path.actions';
+import {
+  APP_PATH,
+  PUBLIC_CYBERSECURITY_SOLUTIONS_PATH,
+} from '@/utils/path/constant';
+import { documentItem_fragment$data } from '@generated/documentItem_fragment.graphql';
+import { IntegrationType, ServiceRestriction } from '@graphql/generated';
+import { useContext, useState } from 'react';
+
+import {
+  isIntegrationItem,
+  ShareableResourceType,
+} from '@/utils/shareable-resources/shareable-resources.types';
+import { MoreVertIcon } from '@filigran/icon';
+import { toast } from '@filigran/ui';
+import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+
+interface DocumentActionsCellProps {
+  document: documentItem_fragment$data;
+}
+
+export const DocumentActionsCell = ({ document }: DocumentActionsCellProps) => {
+  const { settings } = useContext(SettingsContext);
+  const { serviceInstance, translationKey, setIntegrationType } =
+    useServiceContext();
+  const t = useTranslations();
+  const router = useRouter();
+  const [openSheet, setOpenSheet] = useState(false);
+
+  const userCanUpdate = useServiceCapability(
+    ServiceRestriction.Upload,
+    serviceInstance
+  );
+  const userCanDelete = useServiceCapability(
+    ServiceRestriction.Delete,
+    serviceInstance
+  );
+
+  const onClickOnUpdate = () => {
+    if (isIntegrationItem(document)) {
+      setIntegrationType(
+        (document.integration_type as IntegrationType) ??
+          IntegrationType.CsvFeed
+      );
+    }
+
+    setOpenSheet(true);
+  };
+
+  const context = useDocumentContext({
+    serviceInstance,
+    type: document.type as ShareableResourceType,
+  });
+
+  function onDeleteCompleted() {
+    revalidatePathActions([
+      `/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}`,
+    ]).then(() => {
+      router.push(
+        `/${APP_PATH}/service/${serviceInstance.service_definition!.identifier}/${serviceInstance.id}`
+      );
+      toast({
+        title: t('Utils.Success'),
+        description: t(`${translationKey}.Actions.Deleted`, {
+          name: document.name ?? '',
+        }),
+      });
+    });
+  }
+
+  return (
+    <div
+      className="flex items-center gap-xs"
+      onClick={(event) => event.stopPropagation()}>
+      <ShareLinkButton
+        documentId={document.id}
+        url={`${settings!.base_url_front}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${document.slug}`}
+      />
+      {(userCanDelete || userCanUpdate) && (
+        <IconActions
+          className="z-[2]"
+          icon={
+            <>
+              <MoreVertIcon className="h-4 w-4 text-primary" />
+              <span className="sr-only">{t('Utils.OpenMenu')}</span>
+            </>
+          }>
+          {userCanUpdate && (
+            <IconActionsItem onClick={() => onClickOnUpdate()}>
+              {t('MenuActions.Update')}
+            </IconActionsItem>
+          )}
+          {userCanDelete && (
+            <ServiceDelete
+              type={'menuitem'}
+              userCanDelete={userCanDelete}
+              onDelete={() =>
+                context.handleDeleteSheet(document, onDeleteCompleted)
+              }
+              serviceName={serviceInstance.name}
+              integrationType={
+                (isIntegrationItem(document)
+                  ? document.integration_type
+                  : document.type) as CardTypeEnum
+              }
+            />
+          )}
+        </IconActions>
+      )}
+      {userCanUpdate && (
+        <ServiceManageSheet
+          document={document}
+          open={openSheet}
+          setOpen={setOpenSheet}
+        />
+      )}
+    </div>
+  );
+};

--- a/apps/frontend/src/components/service/components/DocumentList.test.tsx
+++ b/apps/frontend/src/components/service/components/DocumentList.test.tsx
@@ -1,24 +1,89 @@
 import testRender from '@/utils/test/test-render';
+import { toast } from '@filigran/ui';
 import { documentItem_fragment$data } from '@generated/documentItem_fragment.graphql';
-import { screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { IntegrationType } from '@graphql/generated';
+import { screen, waitFor, within } from '@testing-library/react';
+import { useRouter } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import DocumentList from './DocumentList';
+import { ServiceListDisplayModeEnum } from './header/ServiceListHeader';
+
+const ServiceIdentifier = 'opencti';
+const ServiceInstanceId = 'service-instance-1';
+const FirstDocumentId = 'doc-1';
+const FirstDocumentSlug = 'first-document';
+const FirstDocumentName = 'First document';
+const FirstDocumentDescription = 'Description 1';
+const SecondDocumentId = 'doc-2';
+const SecondDocumentSlug = 'second-document';
+const SecondDocumentName = 'Second document';
+const SecondDocumentDescription = 'Description 2';
+const ServiceSlug = 'my-service';
+const TranslationKey = 'Service.Connector';
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  setIntegrationType: vi.fn(),
+  handleDeleteSheet: vi.fn(),
+  revalidatePathActions: vi.fn(),
+}));
 
 vi.mock('@/components/service/components/ServiceContext', () => ({
   useServiceContext: () => ({
-    translationKey: 'Service.Connector',
+    translationKey: TranslationKey,
     serviceInstance: {
-      id: 'service-instance-1',
-      slug: 'my-service',
+      id: ServiceInstanceId,
+      slug: ServiceSlug,
       service_definition: {
         identifier: 'opencti',
       },
+      name: 'My service',
     },
-    setIntegrationType: vi.fn(),
+    setIntegrationType: mocks.setIntegrationType,
   }),
 }));
 
+vi.mock('@/hooks/use-service-capability', () => ({
+  default: () => true,
+}));
+
+vi.mock('@/components/service/document/use-document-context', () => ({
+  useDocumentContext: () => ({
+    handleDeleteSheet: mocks.handleDeleteSheet,
+  }),
+}));
+
+vi.mock('@/utils/actions/revalidate-path.actions', () => ({
+  default: mocks.revalidatePathActions,
+}));
+
+vi.mock('@/components/service/components/ServiceManageSheet', () => ({
+  ServiceManageSheet: () => null,
+}));
+
+vi.mock('@filigran/ui', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@filigran/ui')>()),
+  toast: vi.fn(),
+}));
+
 describe('DocumentList', () => {
+  beforeEach(() => {
+    vi.mocked(useRouter).mockReturnValue({
+      push: mocks.push,
+      replace: vi.fn(),
+      prefetch: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+    });
+    mocks.revalidatePathActions.mockResolvedValue(undefined);
+    mocks.handleDeleteSheet.mockImplementation(
+      (_document: documentItem_fragment$data, onDeleteCompleted: () => void) => {
+        onDeleteCompleted();
+      }
+    );
+  });
+
   it('renders one service card per document with expected URLs', () => {
     const documents = [
       {
@@ -39,7 +104,12 @@ describe('DocumentList', () => {
       },
     ] as documentItem_fragment$data[];
 
-    testRender(<DocumentList documents={documents} />);
+    testRender(
+      <DocumentList
+        documents={documents}
+        displayMode={ServiceListDisplayModeEnum.Tab}
+      />
+    );
 
     expect(screen.getByText('First document')).toBeInTheDocument();
     expect(screen.getByText('Second document')).toBeInTheDocument();
@@ -57,5 +127,75 @@ describe('DocumentList', () => {
       'href',
       '/app/service/opencti/service-instance-1/doc-2'
     );
+  });
+
+  it('should set integration type when clicking update on integration item', async () => {
+    // Given
+    const documents = [
+      {
+        id: FirstDocumentId,
+        slug: FirstDocumentSlug,
+        name: FirstDocumentName,
+        type: 'opencti_integration',
+        integration_type: IntegrationType.TaxiiFeed,
+        short_description: FirstDocumentDescription,
+        use_cases: [],
+      },
+    ] as documentItem_fragment$data[];
+    const { user } = testRender(
+      <DocumentList
+        documents={documents}
+        displayMode={ServiceListDisplayModeEnum.List}
+      />
+    );
+
+    // When
+    await user.click(screen.getByRole('button', { name: 'Utils.OpenMenu' }));
+    await user.click(screen.getByRole('menuitem', { name: 'MenuActions.Update' }));
+
+    // Then
+    expect(mocks.setIntegrationType).toHaveBeenCalledWith(
+      IntegrationType.TaxiiFeed
+    );
+  });
+
+  it('should revalidate, toast and navigate to service page when delete completes', async () => {
+    // Given
+    const documents = [
+      {
+        id: FirstDocumentId,
+        slug: FirstDocumentSlug,
+        name: FirstDocumentName,
+        type: 'opencti_integration',
+        short_description: FirstDocumentDescription,
+        use_cases: [],
+      },
+    ] as documentItem_fragment$data[];
+    const { user } = testRender(
+      <DocumentList
+        documents={documents}
+        displayMode={ServiceListDisplayModeEnum.List}
+      />
+    );
+
+    // When
+    await user.click(screen.getByRole('button', { name: 'Utils.OpenMenu' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Utils.Delete' }));
+    const dialog = await screen.findByRole('alertdialog');
+    await user.click(within(dialog).getByRole('button', { name: 'Utils.Delete' }));
+
+    // Then
+    expect(mocks.revalidatePathActions).toHaveBeenCalledWith([
+      `/cybersecurity-solutions/${ServiceSlug}`,
+    ]);
+    expect(toast).toHaveBeenCalledWith({
+      title: 'Utils.Success',
+      description: `${TranslationKey}.Actions.Deleted`,
+    });
+    await waitFor(() => {
+      expect(mocks.push).toHaveBeenCalledWith(
+        `/app/service/${ServiceIdentifier}/${ServiceInstanceId}`
+      );
+    });
   });
 });

--- a/apps/frontend/src/components/service/components/DocumentList.test.tsx
+++ b/apps/frontend/src/components/service/components/DocumentList.test.tsx
@@ -6,7 +6,7 @@ import { screen, waitFor, within } from '@testing-library/react';
 import { useRouter } from 'next/navigation';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import DocumentList from './DocumentList';
-import { ServiceListDisplayModeEnum } from './header/ServiceListHeader';
+import { ServiceListDisplayMode } from './header/ServiceListHeader';
 
 const ServiceIdentifier = 'opencti';
 const ServiceInstanceId = 'service-instance-1';
@@ -112,7 +112,7 @@ describe('DocumentList', () => {
     testRender(
       <DocumentList
         documents={documents}
-        displayMode={ServiceListDisplayModeEnum.Tab}
+        displayMode={ServiceListDisplayMode.Tab}
       />
     );
 
@@ -150,7 +150,7 @@ describe('DocumentList', () => {
     const { user } = testRender(
       <DocumentList
         documents={documents}
-        displayMode={ServiceListDisplayModeEnum.List}
+        displayMode={ServiceListDisplayMode.List}
       />
     );
 
@@ -182,7 +182,7 @@ describe('DocumentList', () => {
     const { user } = testRender(
       <DocumentList
         documents={documents}
-        displayMode={ServiceListDisplayModeEnum.List}
+        displayMode={ServiceListDisplayMode.List}
       />
     );
 
@@ -213,7 +213,7 @@ describe('DocumentList', () => {
     const { user } = testRender(
       <DocumentList
         documents={documents}
-        displayMode={ServiceListDisplayModeEnum.List}
+        displayMode={ServiceListDisplayMode.List}
       />
     );
 

--- a/apps/frontend/src/components/service/components/DocumentList.test.tsx
+++ b/apps/frontend/src/components/service/components/DocumentList.test.tsx
@@ -35,7 +35,7 @@ vi.mock('@/components/service/components/ServiceContext', () => ({
       id: ServiceInstanceId,
       slug: ServiceSlug,
       service_definition: {
-        identifier: 'opencti',
+        identifier: ServiceIdentifier,
       },
       name: 'My service',
     },
@@ -78,32 +78,37 @@ describe('DocumentList', () => {
     });
     mocks.revalidatePathActions.mockResolvedValue(undefined);
     mocks.handleDeleteSheet.mockImplementation(
-      (_document: documentItem_fragment$data, onDeleteCompleted: () => void) => {
+      (
+        _document: documentItem_fragment$data,
+        onDeleteCompleted: () => void
+      ) => {
         onDeleteCompleted();
       }
     );
   });
 
   it('renders one service card per document with expected URLs', () => {
+    // Given
     const documents = [
       {
-        id: 'doc-1',
-        slug: 'first-document',
-        name: 'First document',
+        id: FirstDocumentId,
+        slug: FirstDocumentSlug,
+        name: FirstDocumentName,
         type: 'opencti_integration',
-        short_description: 'Description 1',
+        short_description: FirstDocumentDescription,
         use_cases: [],
       },
       {
-        id: 'doc-2',
-        slug: 'second-document',
-        name: 'Second document',
+        id: SecondDocumentId,
+        slug: SecondDocumentSlug,
+        name: SecondDocumentName,
         type: 'opencti_integration',
-        short_description: 'Description 2',
+        short_description: SecondDocumentDescription,
         use_cases: [],
       },
     ] as documentItem_fragment$data[];
 
+    // When
     testRender(
       <DocumentList
         documents={documents}
@@ -111,8 +116,9 @@ describe('DocumentList', () => {
       />
     );
 
-    expect(screen.getByText('First document')).toBeInTheDocument();
-    expect(screen.getByText('Second document')).toBeInTheDocument();
+    // Then
+    expect(screen.getByText(FirstDocumentName)).toBeInTheDocument();
+    expect(screen.getByText(SecondDocumentName)).toBeInTheDocument();
 
     const detailLinks = screen
       .getAllByRole('link')
@@ -121,11 +127,39 @@ describe('DocumentList', () => {
     expect(detailLinks).toHaveLength(2);
     expect(detailLinks[0]).toHaveAttribute(
       'href',
-      '/app/service/opencti/service-instance-1/doc-1'
+      `/app/service/${ServiceIdentifier}/${ServiceInstanceId}/${FirstDocumentId}`
     );
     expect(detailLinks[1]).toHaveAttribute(
       'href',
-      '/app/service/opencti/service-instance-1/doc-2'
+      `/app/service/${ServiceIdentifier}/${ServiceInstanceId}/${SecondDocumentId}`
+    );
+  });
+
+  it('should navigate to detail page when clicking a row in list mode', async () => {
+    // Given
+    const documents = [
+      {
+        id: FirstDocumentId,
+        slug: FirstDocumentSlug,
+        name: FirstDocumentName,
+        type: 'opencti_integration',
+        short_description: FirstDocumentDescription,
+        use_cases: [],
+      },
+    ] as documentItem_fragment$data[];
+    const { user } = testRender(
+      <DocumentList
+        documents={documents}
+        displayMode={ServiceListDisplayModeEnum.List}
+      />
+    );
+
+    // When
+    await user.click(screen.getByText(FirstDocumentName).closest('tr')!);
+
+    // Then
+    expect(mocks.push).toHaveBeenCalledWith(
+      `/app/service/${ServiceIdentifier}/${ServiceInstanceId}/${FirstDocumentId}`
     );
   });
 
@@ -151,7 +185,9 @@ describe('DocumentList', () => {
 
     // When
     await user.click(screen.getByRole('button', { name: 'Utils.OpenMenu' }));
-    await user.click(screen.getByRole('menuitem', { name: 'MenuActions.Update' }));
+    await user.click(
+      screen.getByRole('menuitem', { name: 'MenuActions.Update' })
+    );
 
     // Then
     expect(mocks.setIntegrationType).toHaveBeenCalledWith(
@@ -182,7 +218,9 @@ describe('DocumentList', () => {
     await user.click(screen.getByRole('button', { name: 'Utils.OpenMenu' }));
     await user.click(screen.getByRole('menuitem', { name: 'Utils.Delete' }));
     const dialog = await screen.findByRole('alertdialog');
-    await user.click(within(dialog).getByRole('button', { name: 'Utils.Delete' }));
+    await user.click(
+      within(dialog).getByRole('button', { name: 'Utils.Delete' })
+    );
 
     // Then
     expect(mocks.revalidatePathActions).toHaveBeenCalledWith([

--- a/apps/frontend/src/components/service/components/DocumentList.test.tsx
+++ b/apps/frontend/src/components/service/components/DocumentList.test.tsx
@@ -161,6 +161,9 @@ describe('DocumentList', () => {
     expect(mocks.push).toHaveBeenCalledWith(
       `/app/service/${ServiceIdentifier}/${ServiceInstanceId}/${FirstDocumentId}`
     );
+    expect(
+      screen.queryByLabelText('Manage columns visibility')
+    ).not.toBeInTheDocument();
   });
 
   it('should set integration type when clicking update on integration item', async () => {

--- a/apps/frontend/src/components/service/components/DocumentList.tsx
+++ b/apps/frontend/src/components/service/components/DocumentList.tsx
@@ -1,14 +1,12 @@
 'use client';
 
+import { DocumentActionsCell } from '@/components/service/components/DocumentActionsCell';
 import {
   DocumentNameCell,
   DocumentShortDescriptionCell,
 } from '@/components/service/components/DocumentListCells';
 import { buildMetadataColumns } from '@/components/service/components/DocumentListColumns';
-import {
-  ServiceListDisplayMode,
-  ServiceListDisplayModeEnum,
-} from '@/components/service/components/header/ServiceListHeader';
+import { ServiceListDisplayMode } from '@/components/service/components/header/ServiceListHeader';
 import ServiceCard from '@/components/service/components/ServiceCard';
 import { useServiceContext } from '@/components/service/components/ServiceContext';
 import { SettingsContext } from '@/components/settings/EnvPortalContext';
@@ -17,28 +15,13 @@ import {
   PUBLIC_CYBERSECURITY_SOLUTIONS_PATH,
 } from '@/utils/path/constant';
 import { documentItem_fragment$data } from '@generated/documentItem_fragment.graphql';
-import { IntegrationType, ServiceRestriction } from '@graphql/generated';
-import { useContext, useMemo, useState } from 'react';
+import { useContext, useMemo } from 'react';
 
-import {
-  CardTypeEnum,
-  ServiceDelete,
-} from '@/components/service/components/ServiceDelete';
-import { ServiceManageSheet } from '@/components/service/components/ServiceManageSheet';
-import { useDocumentContext } from '@/components/service/document/use-document-context';
 import BadgeOverflowCounter, {
   BadgeOverflow,
 } from '@/components/ui/BadgeOverflowCounter';
-import { IconActions, IconActionsItem } from '@/components/ui/IconActions';
-import { ShareLinkButton } from '@/components/ui/share-link/ShareLinkButton';
-import useServiceCapability from '@/hooks/use-service-capability';
-import revalidatePathActions from '@/utils/actions/revalidate-path.actions';
-import {
-  isIntegrationItem,
-  ShareableResourceType,
-} from '@/utils/shareable-resources/shareable-resources.types';
-import { MoreVertIcon } from '@filigran/icon';
-import { DataTable, toast } from '@filigran/ui';
+import useScrollPosition from '@/hooks/use-scroll-position';
+import { DataTable } from '@filigran/ui';
 import { ColumnDef } from '@tanstack/react-table';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
@@ -49,109 +32,6 @@ interface DocumentListProps {
   connectionId?: string;
 }
 
-interface DocumentActionsCellProps {
-  document: documentItem_fragment$data;
-}
-
-const DocumentActionsCell = ({ document }: DocumentActionsCellProps) => {
-  const { settings } = useContext(SettingsContext);
-  const { serviceInstance, translationKey, setIntegrationType } =
-    useServiceContext();
-  const t = useTranslations();
-  const router = useRouter();
-  const [openSheet, setOpenSheet] = useState(false);
-
-  const userCanUpdate = useServiceCapability(
-    ServiceRestriction.Upload,
-    serviceInstance
-  );
-  const userCanDelete = useServiceCapability(
-    ServiceRestriction.Delete,
-    serviceInstance
-  );
-
-  const onClickOnUpdate = () => {
-    if (isIntegrationItem(document)) {
-      setIntegrationType(
-        (document.integration_type as IntegrationType) ??
-          IntegrationType.CsvFeed
-      );
-    }
-
-    setOpenSheet(true);
-  };
-
-  const context = useDocumentContext({
-    serviceInstance,
-    type: document.type as ShareableResourceType,
-  });
-
-  function onDeleteCompleted() {
-    revalidatePathActions([
-      `/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}`,
-    ]).then(() => {
-      router.push(
-        `/${APP_PATH}/service/${serviceInstance.service_definition!.identifier}/${serviceInstance.id}`
-      );
-    });
-    toast({
-      title: t('Utils.Success'),
-      description: t(`${translationKey}.Actions.Deleted`, {
-        name: document.name ?? '',
-      }),
-    });
-  }
-
-  return (
-    <div
-      className="flex items-center gap-xs"
-      onClick={(event) => event.stopPropagation()}>
-      <ShareLinkButton
-        documentId={document.id}
-        url={`${settings!.base_url_front}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${document.slug}`}
-      />
-      {(userCanDelete || userCanUpdate) && (
-        <IconActions
-          className="z-[2]"
-          icon={
-            <>
-              <MoreVertIcon className="h-4 w-4 text-primary" />
-              <span className="sr-only">{t('Utils.OpenMenu')}</span>
-            </>
-          }>
-          {userCanUpdate && (
-            <IconActionsItem onClick={() => onClickOnUpdate()}>
-              {t('MenuActions.Update')}
-            </IconActionsItem>
-          )}
-          {userCanDelete && (
-            <ServiceDelete
-              type={'menuitem'}
-              userCanDelete={userCanDelete}
-              onDelete={() =>
-                context.handleDeleteSheet(document, onDeleteCompleted)
-              }
-              serviceName={serviceInstance.name}
-              integrationType={
-                (isIntegrationItem(document)
-                  ? document.integration_type
-                  : document.type) as CardTypeEnum
-              }
-            />
-          )}
-        </IconActions>
-      )}
-      {userCanUpdate && (
-        <ServiceManageSheet
-          document={document}
-          open={openSheet}
-          setOpen={setOpenSheet}
-        />
-      )}
-    </div>
-  );
-};
-
 const DocumentList = ({
   documents,
   displayMode,
@@ -161,6 +41,7 @@ const DocumentList = ({
   const { serviceInstance } = useServiceContext();
   const t = useTranslations();
   const router = useRouter();
+  const { save } = useScrollPosition();
   const columns: ColumnDef<documentItem_fragment$data>[] = useMemo(
     () => [
       {
@@ -196,6 +77,8 @@ const DocumentList = ({
       {
         accessorKey: 'action',
         id: 'action',
+        enableHiding: false,
+        enableSorting: false,
         header: t('Service.List.Tab.Actions'),
         cell: ({ row }) => <DocumentActionsCell document={row.original} />,
       },
@@ -215,7 +98,7 @@ const DocumentList = ({
 
   return (
     <>
-      {displayMode === ServiceListDisplayModeEnum.Tab ? (
+      {displayMode === ServiceListDisplayMode.Tab ? (
         <ul
           className={
             'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-l'
@@ -235,11 +118,12 @@ const DocumentList = ({
           columns={tableColumns}
           data={documents}
           toolbar={<></>}
-          onClickRow={(row) =>
+          onClickRow={(row) => {
+            save();
             router.push(
               `/${APP_PATH}/service/${serviceInstance.service_definition?.identifier}/${serviceInstance.id}/${row.original.id}`
-            )
-          }
+            );
+          }}
         />
       )}
     </>

--- a/apps/frontend/src/components/service/components/DocumentList.tsx
+++ b/apps/frontend/src/components/service/components/DocumentList.tsx
@@ -103,7 +103,9 @@ const DocumentActionsCell = ({ document }: DocumentActionsCellProps) => {
   }
 
   return (
-    <div className="flex items-center gap-xs">
+    <div
+      className="flex items-center gap-xs"
+      onClick={(event) => event.stopPropagation()}>
       <ShareLinkButton
         documentId={document.id}
         url={`${settings!.base_url_front}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${document.slug}`}
@@ -152,6 +154,7 @@ const DocumentList = ({ documents, displayMode, connectionId }: DocumentListProp
   const { settings } = useContext(SettingsContext);
   const { serviceInstance } = useServiceContext();
   const t = useTranslations();
+  const router = useRouter();
   const columns: ColumnDef<documentItem_fragment$data>[] = useMemo(
     () => [
       {
@@ -225,6 +228,11 @@ const DocumentList = ({ documents, displayMode, connectionId }: DocumentListProp
         <DataTable
           columns={tableColumns}
           data={documents}
+          onClickRow={(row) =>
+            router.push(
+              `/${APP_PATH}/service/${serviceInstance.service_definition?.identifier}/${serviceInstance.id}/${row.original.id}`
+            )
+          }
         />
       )}
     </>

--- a/apps/frontend/src/components/service/components/DocumentList.tsx
+++ b/apps/frontend/src/components/service/components/DocumentList.tsx
@@ -110,35 +110,37 @@ const DocumentActionsCell = ({ document }: DocumentActionsCellProps) => {
         documentId={document.id}
         url={`${settings!.base_url_front}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${document.slug}`}
       />
-      <IconActions
-        className="z-[2]"
-        icon={
-          <>
-            <MoreVertIcon className="h-4 w-4 text-primary" />
-            <span className="sr-only">{t('Utils.OpenMenu')}</span>
-          </>
-        }>
-        {userCanUpdate && (
-          <IconActionsItem onClick={() => onClickOnUpdate()}>
-            {t('MenuActions.Update')}
-          </IconActionsItem>
-        )}
-        {userCanDelete && (
-          <ServiceDelete
-            type={'menuitem'}
-            userCanDelete={userCanDelete}
-            onDelete={() =>
-              context.handleDeleteSheet(document, onDeleteCompleted)
-            }
-            serviceName={serviceInstance.name}
-            integrationType={
-              (isIntegrationItem(document)
-                ? document.integration_type
-                : document.type) as CardTypeEnum
-            }
-          />
-        )}
-      </IconActions>
+      {(userCanDelete || userCanUpdate) && (
+        <IconActions
+          className="z-[2]"
+          icon={
+            <>
+              <MoreVertIcon className="h-4 w-4 text-primary" />
+              <span className="sr-only">{t('Utils.OpenMenu')}</span>
+            </>
+          }>
+          {userCanUpdate && (
+            <IconActionsItem onClick={() => onClickOnUpdate()}>
+              {t('MenuActions.Update')}
+            </IconActionsItem>
+          )}
+          {userCanDelete && (
+            <ServiceDelete
+              type={'menuitem'}
+              userCanDelete={userCanDelete}
+              onDelete={() =>
+                context.handleDeleteSheet(document, onDeleteCompleted)
+              }
+              serviceName={serviceInstance.name}
+              integrationType={
+                (isIntegrationItem(document)
+                  ? document.integration_type
+                  : document.type) as CardTypeEnum
+              }
+            />
+          )}
+        </IconActions>
+      )}
       {userCanUpdate && (
         <ServiceManageSheet
           document={document}
@@ -150,7 +152,11 @@ const DocumentActionsCell = ({ document }: DocumentActionsCellProps) => {
   );
 };
 
-const DocumentList = ({ documents, displayMode, connectionId }: DocumentListProps) => {
+const DocumentList = ({
+  documents,
+  displayMode,
+  connectionId,
+}: DocumentListProps) => {
   const { settings } = useContext(SettingsContext);
   const { serviceInstance } = useServiceContext();
   const t = useTranslations();
@@ -228,6 +234,7 @@ const DocumentList = ({ documents, displayMode, connectionId }: DocumentListProp
         <DataTable
           columns={tableColumns}
           data={documents}
+          toolbar={<></>}
           onClickRow={(row) =>
             router.push(
               `/${APP_PATH}/service/${serviceInstance.service_definition?.identifier}/${serviceInstance.id}/${row.original.id}`

--- a/apps/frontend/src/components/service/components/DocumentList.tsx
+++ b/apps/frontend/src/components/service/components/DocumentList.tsx
@@ -1,3 +1,14 @@
+'use client';
+
+import {
+  DocumentNameCell,
+  DocumentShortDescriptionCell,
+} from '@/components/service/components/DocumentListCells';
+import { buildMetadataColumns } from '@/components/service/components/DocumentListColumns';
+import {
+  ServiceListDisplayMode,
+  ServiceListDisplayModeEnum,
+} from '@/components/service/components/header/ServiceListHeader';
 import ServiceCard from '@/components/service/components/ServiceCard';
 import { useServiceContext } from '@/components/service/components/ServiceContext';
 import { SettingsContext } from '@/components/settings/EnvPortalContext';
@@ -6,32 +17,217 @@ import {
   PUBLIC_CYBERSECURITY_SOLUTIONS_PATH,
 } from '@/utils/path/constant';
 import { documentItem_fragment$data } from '@generated/documentItem_fragment.graphql';
-import { useContext } from 'react';
+import { IntegrationType, ServiceRestriction } from '@graphql/generated';
+import { useContext, useMemo, useState } from 'react';
+
+import {
+  CardTypeEnum,
+  ServiceDelete,
+} from '@/components/service/components/ServiceDelete';
+import { ServiceManageSheet } from '@/components/service/components/ServiceManageSheet';
+import { useDocumentContext } from '@/components/service/document/use-document-context';
+import BadgeOverflowCounter, {
+  BadgeOverflow,
+} from '@/components/ui/BadgeOverflowCounter';
+import { IconActions, IconActionsItem } from '@/components/ui/IconActions';
+import { ShareLinkButton } from '@/components/ui/share-link/ShareLinkButton';
+import useServiceCapability from '@/hooks/use-service-capability';
+import revalidatePathActions from '@/utils/actions/revalidate-path.actions';
+import {
+  isIntegrationItem,
+  ShareableResourceType,
+} from '@/utils/shareable-resources/shareable-resources.types';
+import { MoreVertIcon } from '@filigran/icon';
+import { DataTable, toast } from '@filigran/ui';
+import { ColumnDef } from '@tanstack/react-table';
+import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
 
 interface DocumentListProps {
   documents: documentItem_fragment$data[];
+  displayMode: ServiceListDisplayMode;
   connectionId?: string;
 }
 
-const DocumentList = ({ documents, connectionId }: DocumentListProps) => {
+interface DocumentActionsCellProps {
+  document: documentItem_fragment$data;
+}
+
+const DocumentActionsCell = ({ document }: DocumentActionsCellProps) => {
   const { settings } = useContext(SettingsContext);
-  const { serviceInstance } = useServiceContext();
+  const { serviceInstance, translationKey, setIntegrationType } =
+    useServiceContext();
+  const t = useTranslations();
+  const router = useRouter();
+  const [openSheet, setOpenSheet] = useState(false);
+
+  const userCanUpdate = useServiceCapability(
+    ServiceRestriction.Upload,
+    serviceInstance
+  );
+  const userCanDelete = useServiceCapability(
+    ServiceRestriction.Delete,
+    serviceInstance
+  );
+
+  const onClickOnUpdate = () => {
+    if (isIntegrationItem(document)) {
+      setIntegrationType(
+        (document.integration_type as IntegrationType) ??
+          IntegrationType.CsvFeed
+      );
+    }
+
+    setOpenSheet(true);
+  };
+
+  const context = useDocumentContext({
+    serviceInstance,
+    type: document.type as ShareableResourceType,
+  });
+
+  function onDeleteCompleted() {
+    revalidatePathActions([
+      `/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}`,
+    ]).then(() => {
+      router.push(
+        `/${APP_PATH}/service/${serviceInstance.service_definition!.identifier}/${serviceInstance.id}`
+      );
+    });
+    toast({
+      title: t('Utils.Success'),
+      description: t(`${translationKey}.Actions.Deleted`, {
+        name: document.name ?? '',
+      }),
+    });
+  }
 
   return (
-    <ul
-      className={
-        'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-l'
-      }>
-      {documents.map((document) => (
-        <ServiceCard
-          key={document.id}
+    <div className="flex items-center gap-xs">
+      <ShareLinkButton
+        documentId={document.id}
+        url={`${settings!.base_url_front}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${document.slug}`}
+      />
+      <IconActions
+        className="z-[2]"
+        icon={
+          <>
+            <MoreVertIcon className="h-4 w-4 text-primary" />
+            <span className="sr-only">{t('Utils.OpenMenu')}</span>
+          </>
+        }>
+        {userCanUpdate && (
+          <IconActionsItem onClick={() => onClickOnUpdate()}>
+            {t('MenuActions.Update')}
+          </IconActionsItem>
+        )}
+        {userCanDelete && (
+          <ServiceDelete
+            type={'menuitem'}
+            userCanDelete={userCanDelete}
+            onDelete={() =>
+              context.handleDeleteSheet(document, onDeleteCompleted)
+            }
+            serviceName={serviceInstance.name}
+            integrationType={
+              (isIntegrationItem(document)
+                ? document.integration_type
+                : document.type) as CardTypeEnum
+            }
+          />
+        )}
+      </IconActions>
+      {userCanUpdate && (
+        <ServiceManageSheet
           document={document}
-          connectionId={connectionId}
-          detailUrl={`/${APP_PATH}/service/${serviceInstance.service_definition?.identifier}/${serviceInstance.id}/${document.id}`}
-          shareLinkUrl={`${settings!.base_url_front}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${document.slug}`}
+          open={openSheet}
+          setOpen={setOpenSheet}
         />
-      ))}
-    </ul>
+      )}
+    </div>
+  );
+};
+
+const DocumentList = ({ documents, displayMode, connectionId }: DocumentListProps) => {
+  const { settings } = useContext(SettingsContext);
+  const { serviceInstance } = useServiceContext();
+  const t = useTranslations();
+  const columns: ColumnDef<documentItem_fragment$data>[] = useMemo(
+    () => [
+      {
+        accessorKey: 'name',
+        id: 'name',
+        header: t('Service.List.Tab.Name'),
+        cell: ({ row }) => <DocumentNameCell document={row.original} />,
+      },
+      {
+        accessorKey: 'short_description',
+        id: 'short_description',
+        header: t('Service.List.Tab.Description'),
+        cell: ({ row }) => (
+          <DocumentShortDescriptionCell document={row.original} />
+        ),
+      },
+      {
+        accessorKey: 'use_cases',
+        id: 'use_cases',
+        header: t('Service.List.Tab.UseCases'),
+        cell: ({ row }) => {
+          const document = row.original;
+
+          return (
+            <BadgeOverflowCounter
+              formatLabel={false}
+              badges={document.use_cases as BadgeOverflow[]}
+              className="z-2 shrink-0"
+            />
+          );
+        },
+      },
+      {
+        accessorKey: 'action',
+        id: 'action',
+        header: t('Service.List.Tab.Actions'),
+        cell: ({ row }) => <DocumentActionsCell document={row.original} />,
+      },
+    ],
+    [t]
+  );
+
+  const tableColumns = useMemo(
+    () =>
+      buildMetadataColumns({
+        columns,
+        documents,
+        t,
+      }),
+    [columns, documents, t]
+  );
+
+  return (
+    <>
+      {displayMode === ServiceListDisplayModeEnum.Tab ? (
+        <ul
+          className={
+            'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-l'
+          }>
+          {documents.map((document) => (
+            <ServiceCard
+              key={document.id}
+              document={document}
+              connectionId={connectionId}
+              detailUrl={`/${APP_PATH}/service/${serviceInstance.service_definition?.identifier}/${serviceInstance.id}/${document.id}`}
+              shareLinkUrl={`${settings!.base_url_front}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${document.slug}`}
+            />
+          ))}
+        </ul>
+      ) : (
+        <DataTable
+          columns={tableColumns}
+          data={documents}
+        />
+      )}
+    </>
   );
 };
 

--- a/apps/frontend/src/components/service/components/DocumentListCells.test.tsx
+++ b/apps/frontend/src/components/service/components/DocumentListCells.test.tsx
@@ -1,0 +1,78 @@
+import testRender from '@/utils/test/test-render';
+import { documentItem_fragment$data } from '@generated/documentItem_fragment.graphql';
+import { IntegrationType } from '@graphql/generated';
+import { describe, expect, it } from 'vitest';
+import {
+  DocumentNameCell,
+  DocumentShortDescriptionCell,
+} from './DocumentListCells';
+
+describe('DocumentNameCell', () => {
+  it('renders connector status icons when document is a connector', () => {
+    const document = {
+      name: 'Connector document',
+      active: true,
+      integration_type: IntegrationType.Connector,
+      manager_supported: true,
+      verified: true,
+    } as unknown as documentItem_fragment$data;
+
+    const { container, getByText } = testRender(
+      <DocumentNameCell document={document} />
+    );
+
+    expect(getByText('Connector document')).toBeInTheDocument();
+    expect(container.querySelectorAll('svg')).toHaveLength(2);
+  });
+
+  it('does not render status icons for non-connector documents', () => {
+    const document = {
+      name: 'CSV document',
+      active: true,
+      integration_type: IntegrationType.CsvFeed,
+      manager_supported: true,
+      verified: true,
+    } as unknown as documentItem_fragment$data;
+
+    const { container, getByText } = testRender(
+      <DocumentNameCell document={document} />
+    );
+
+    expect(getByText('CSV document')).toBeInTheDocument();
+    expect(container.querySelectorAll('svg')).toHaveLength(0);
+  });
+});
+
+describe('DocumentShortDescriptionCell', () => {
+  it.each`
+    shortDescription
+    ${null}
+    ${undefined}
+    ${''}
+  `(
+    'renders nothing when short_description is "$shortDescription"',
+    ({ shortDescription }) => {
+      const document = {
+        short_description: shortDescription,
+      } as unknown as documentItem_fragment$data;
+
+      const { container } = testRender(
+        <DocumentShortDescriptionCell document={document} />
+      );
+
+      expect(container.firstChild).toBeNull();
+    }
+  );
+
+  it('renders short description text', () => {
+    const document = {
+      short_description: 'A concise summary',
+    } as unknown as documentItem_fragment$data;
+
+    const { getByText } = testRender(
+      <DocumentShortDescriptionCell document={document} />
+    );
+
+    expect(getByText('A concise summary')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/service/components/DocumentListCells.tsx
+++ b/apps/frontend/src/components/service/components/DocumentListCells.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { ResourceStatusIcons } from '@/components/ui/ResourceStatusIcons';
+import { docHasMetadata } from '@/utils/shareable-resources/utils/shareable-resources.client.utils';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@filigran/ui';
+import { documentItem_fragment$data } from '@generated/documentItem_fragment.graphql';
+import { publicDocumentListItemFragment$data } from '@generated/publicDocumentListItemFragment.graphql';
+import { DocumentMetadataKeyCode, IntegrationType } from '@graphql/generated';
+
+interface DocumentNameCellProps {
+  document: documentItem_fragment$data | publicDocumentListItemFragment$data;
+}
+
+export const DocumentNameCell = ({ document }: DocumentNameCellProps) => {
+  const isConnector =
+    docHasMetadata(document, DocumentMetadataKeyCode.IntegrationType) &&
+    document.integration_type === IntegrationType.Connector;
+
+  const deployable =
+    document.active &&
+    isConnector &&
+    docHasMetadata(document, DocumentMetadataKeyCode.ManagerSupported) &&
+    !!document.manager_supported;
+
+  const verified =
+    document.active &&
+    isConnector &&
+    docHasMetadata(document, DocumentMetadataKeyCode.Verified) &&
+    !!document.verified;
+
+  return (
+    <div className="flex items-center gap-xs">
+      <span>{document.name}</span>
+      <ResourceStatusIcons
+        deployable={deployable}
+        verified={verified}
+        displayUnverifiedIcon={isConnector}
+        iconClassName="h-4 w-4 shrink-0 text-alert-success-primary"
+      />
+    </div>
+  );
+};
+
+interface DocumentShortDescriptionCellProps {
+  document: documentItem_fragment$data | publicDocumentListItemFragment$data;
+}
+
+export const DocumentShortDescriptionCell = ({
+  document,
+}: DocumentShortDescriptionCellProps) => {
+  const shortDescription = document.short_description ?? '';
+
+  if (!shortDescription) {
+    return null;
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger className="block w-full truncate text-left">
+          {shortDescription}
+        </TooltipTrigger>
+        <TooltipContent className="max-w-lg">
+          <p>{shortDescription}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};

--- a/apps/frontend/src/components/service/components/DocumentListColumns.test.tsx
+++ b/apps/frontend/src/components/service/components/DocumentListColumns.test.tsx
@@ -95,9 +95,7 @@ describe('buildProductVersionColumn', () => {
       throw new Error('column cell is not defined');
     }
 
-    const { getByText } = testRender(
-      <>{cell(buildCellContext(document))}</>
-    );
+    const { getByText } = testRender(<>{cell(buildCellContext(document))}</>);
 
     expect(getByText('5.0.1')).toBeInTheDocument();
   });
@@ -141,9 +139,7 @@ describe('buildAuthorColumn', () => {
       throw new Error('column cell is not defined');
     }
 
-    const { getByText } = testRender(
-      <>{cell(buildCellContext(document))}</>
-    );
+    const { getByText } = testRender(<>{cell(buildCellContext(document))}</>);
 
     expect(getByText('Alice Doe')).toBeInTheDocument();
   });

--- a/apps/frontend/src/components/service/components/DocumentListColumns.test.tsx
+++ b/apps/frontend/src/components/service/components/DocumentListColumns.test.tsx
@@ -1,0 +1,150 @@
+import testRender from '@/utils/test/test-render';
+import { DocumentMetadataKeyCode, IntegrationType } from '@graphql/generated';
+import { CellContext, ColumnDef } from '@tanstack/react-table';
+import { describe, expect, it } from 'vitest';
+import {
+  buildAuthorColumn,
+  buildMetadataColumns,
+  buildProductVersionColumn,
+} from './DocumentListColumns';
+
+type TestDocument = {
+  integration_type?: string | null;
+  product_version?: string | null;
+  uploader: {
+    first_name?: string | null;
+    last_name?: string | null;
+    email?: string | null;
+  } | null;
+};
+
+const t = (key: string) => key;
+const buildCellContext = (
+  document: TestDocument
+): CellContext<TestDocument, unknown> =>
+  ({ row: { original: document } }) as CellContext<TestDocument, unknown>;
+
+describe('buildMetadataColumns', () => {
+  const baseColumns = [{ id: 'name' }] as ColumnDef<TestDocument>[];
+
+  it('adds author column for non-connector documents', () => {
+    const columns = buildMetadataColumns({
+      columns: baseColumns,
+      documents: [
+        {
+          integration_type: IntegrationType.CsvFeed,
+          uploader: null,
+        },
+      ],
+      t,
+    });
+
+    expect(columns.map((column) => column.id)).toEqual([
+      'name',
+      'author_column',
+    ]);
+  });
+
+  it('does not add author column for connector documents', () => {
+    const columns = buildMetadataColumns({
+      columns: baseColumns,
+      documents: [
+        {
+          integration_type: IntegrationType.Connector,
+          uploader: null,
+        },
+      ],
+      t,
+    });
+
+    expect(columns.map((column) => column.id)).toEqual(['name']);
+  });
+
+  it('adds product version column when product version metadata exists', () => {
+    const columns = buildMetadataColumns({
+      columns: baseColumns,
+      documents: [
+        {
+          integration_type: IntegrationType.CsvFeed,
+          uploader: null,
+          [DocumentMetadataKeyCode.ProductVersion]: true,
+          product_version: '6.1.0',
+        } as TestDocument & Record<DocumentMetadataKeyCode, boolean>,
+      ],
+      t,
+    });
+
+    expect(columns.map((column) => column.id)).toEqual([
+      'name',
+      'author_column',
+      'minimum_deployable_version',
+    ]);
+  });
+});
+
+describe('buildProductVersionColumn', () => {
+  it('renders the product version value when metadata exists', () => {
+    const column = buildProductVersionColumn<TestDocument>(t);
+    const document = {
+      product_version: '5.0.1',
+      uploader: null,
+    } as TestDocument;
+
+    const cell = column.cell;
+    if (!cell) {
+      throw new Error('column cell is not defined');
+    }
+
+    const { getByText } = testRender(
+      <>{cell(buildCellContext(document))}</>
+    );
+
+    expect(getByText('5.0.1')).toBeInTheDocument();
+  });
+
+  it('renders empty value when product version metadata does not exist', () => {
+    // Given
+    const column = buildProductVersionColumn<TestDocument>(t);
+    const document = {
+      uploader: null,
+    } as TestDocument;
+
+    const cell = column.cell;
+    if (!cell) {
+      throw new Error('column cell is not defined');
+    }
+
+    // When
+    const { container, queryByText } = testRender(
+      <>{cell(buildCellContext(document))}</>
+    );
+
+    // Then
+    expect(queryByText('5.0.1')).toBeNull();
+    expect(container.textContent).toBe('');
+  });
+});
+
+describe('buildAuthorColumn', () => {
+  it('renders uploader identity via UserDisplay', () => {
+    const column = buildAuthorColumn<TestDocument>(t);
+    const document = {
+      uploader: {
+        first_name: 'alice',
+        last_name: 'doe',
+        email: 'alice.doe@example.com',
+      },
+    } as TestDocument;
+
+    const cell = column.cell;
+    if (!cell) {
+      throw new Error('column cell is not defined');
+    }
+
+    const { getByText } = testRender(
+      <>{cell(buildCellContext(document))}</>
+    );
+
+    expect(getByText('Alice Doe')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/service/components/DocumentListColumns.tsx
+++ b/apps/frontend/src/components/service/components/DocumentListColumns.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { UserDisplay } from '@/components/ui/UserDisplay';
+import { UseTranslationsProps } from '@/i18n/config';
+import { PublicDocumentData } from '@/utils/shareable-resources/shareable-resources.types';
+import { docHasMetadata } from '@/utils/shareable-resources/utils/shareable-resources.client.utils';
+import { documentItem_fragment$data } from '@generated/documentItem_fragment.graphql';
+import { DocumentMetadataKeyCode, IntegrationType } from '@graphql/generated';
+import { ColumnDef } from '@tanstack/react-table';
+
+type DocumentListMetadataData = {
+  integration_type?: string | null | undefined;
+  product_version?: string | null | undefined;
+  uploader:
+    | documentItem_fragment$data['uploader']
+    | PublicDocumentData['uploader']
+    | null
+    | undefined;
+};
+
+export const buildProductVersionColumn = <T extends DocumentListMetadataData>(
+  t: UseTranslationsProps
+): ColumnDef<T> => ({
+  accessorKey: 'minimum_deployable_version',
+  id: 'minimum_deployable_version',
+  header: t('Service.List.Tab.MinimumDeployableVersion'),
+  cell: ({ row }) => {
+    const document = row.original;
+    return (
+      <span className="text-sm">
+        {docHasMetadata(document, DocumentMetadataKeyCode.ProductVersion)
+          ? document.product_version
+          : null}
+      </span>
+    );
+  },
+});
+
+export const buildAuthorColumn = <T extends DocumentListMetadataData>(
+  t: UseTranslationsProps
+): ColumnDef<T> => ({
+  accessorKey: 'author_column',
+  id: 'author_column',
+  header: t('Service.List.Tab.Author'),
+  cell: ({ row }) => (
+    <UserDisplay
+      displayPicture={false}
+      uploader={row.original.uploader}
+    />
+  ),
+});
+
+export const buildMetadataColumns = <
+  T extends DocumentListMetadataData,
+>(params: {
+  columns: ColumnDef<T>[];
+  documents: T[];
+  t: UseTranslationsProps;
+}) => {
+  const { columns, documents, t } = params;
+  const nextColumns = [...columns];
+  const integrationType = documents[0]?.integration_type;
+  const hasProductVersionColumn = documents.some(
+    (document) =>
+      docHasMetadata(document, DocumentMetadataKeyCode.ProductVersion) &&
+      !!document.product_version
+  );
+
+  if (integrationType !== IntegrationType.Connector) {
+    nextColumns.push(buildAuthorColumn<T>(t));
+  }
+
+  if (hasProductVersionColumn) {
+    nextColumns.push(buildProductVersionColumn<T>(t));
+  }
+
+  return nextColumns;
+};

--- a/apps/frontend/src/components/service/components/ServiceList.test.tsx
+++ b/apps/frontend/src/components/service/components/ServiceList.test.tsx
@@ -1,7 +1,8 @@
 import ServiceList from '@/components/service/components/ServiceList';
-import { ServiceListDisplayModeEnum } from '@/components/service/components/header/ServiceListHeader';
+import { ServiceListDisplayMode } from '@/components/service/components/header/ServiceListHeader';
 import { ServiceListLocalStorageKey } from '@/hooks/use-service-list-local-storage';
 import testRender from '@/utils/test/test-render';
+import { documentItem_fragment$data } from '@generated/documentItem_fragment.graphql';
 import {
   DocumentOrdering,
   IntegrationType,
@@ -65,9 +66,7 @@ vi.mock(
   })
 );
 
-const buildLocalStorageState = (
-  displayMode = ServiceListDisplayModeEnum.Tab
-) => ({
+const buildLocalStorageState = (displayMode = ServiceListDisplayMode.Tab) => ({
   removeLabels: testState.removeLabels,
   displayMode,
   setDisplayMode: testState.setDisplayMode,
@@ -128,7 +127,7 @@ describe('ServiceList', () => {
         short_description: 'Active description',
         use_cases: [],
       },
-    ] as never[];
+    ] as Partial<documentItem_fragment$data>[];
     const draft = [
       {
         id: 'draft-1',
@@ -138,7 +137,7 @@ describe('ServiceList', () => {
         short_description: 'Draft description',
         use_cases: [],
       },
-    ] as never[];
+    ] as Partial<documentItem_fragment$data>[];
 
     testRender(
       <ServiceList
@@ -171,7 +170,7 @@ describe('ServiceList', () => {
         short_description: 'Active description',
         use_cases: [],
       },
-    ] as never[];
+    ] as Partial<documentItem_fragment$data>[];
     const draft = [
       {
         id: 'draft-1',
@@ -181,7 +180,7 @@ describe('ServiceList', () => {
         short_description: 'Draft description',
         use_cases: [],
       },
-    ] as never[];
+    ] as Partial<documentItem_fragment$data>[];
 
     testRender(
       <ServiceList
@@ -215,7 +214,7 @@ describe('ServiceList', () => {
         short_description: 'Dashboard description',
         use_cases: [],
       },
-    ] as never[];
+    ] as Partial<documentItem_fragment$data>[];
 
     const { user } = testRender(
       <ServiceList
@@ -259,7 +258,7 @@ describe('ServiceList', () => {
     );
 
     expect(testState.setDisplayMode).toHaveBeenCalledWith(
-      ServiceListDisplayModeEnum.Tab
+      ServiceListDisplayMode.Tab
     );
   });
 });

--- a/apps/frontend/src/components/service/components/ServiceList.test.tsx
+++ b/apps/frontend/src/components/service/components/ServiceList.test.tsx
@@ -1,0 +1,279 @@
+import ServiceList from '@/components/service/components/ServiceList';
+import { ServiceListDisplayModeEnum } from '@/components/service/components/header/ServiceListHeader';
+import { ServiceListLocalStorageKey } from '@/hooks/use-service-list-local-storage';
+import testRender from '@/utils/test/test-render';
+import {
+  DocumentOrdering,
+  IntegrationType,
+  OrderingMode,
+} from '@graphql/generated';
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next-intl', async (importOriginal) => {
+  const original = await importOriginal<typeof import('next-intl')>();
+  return {
+    ...original,
+    useTranslations: () => {
+      const t = ((key: string) => key) as ((key: string) => string) & {
+        has: (key: string) => boolean;
+      };
+      t.has = () => false;
+      return t;
+    },
+  };
+});
+
+const testState = vi.hoisted(() => ({
+  useServiceContext: vi.fn(),
+  useServiceCapability: vi.fn(),
+  useUserHasPortalCapability: vi.fn(),
+  useServiceListLocalStorageKeyContext: vi.fn(),
+  useServiceListLocalStorage: vi.fn(),
+  useScrollPosition: vi.fn(),
+  setDisplayMode: vi.fn(),
+  setOrderBy: vi.fn(),
+  setOrderMode: vi.fn(),
+  setSelectedFilters: vi.fn(),
+  removeLabels: vi.fn(),
+  restore: vi.fn(),
+  save: vi.fn(),
+  selectedFilters: [] as string[],
+}));
+
+vi.mock('@/components/service/components/ServiceContext', () => ({
+  useServiceContext: testState.useServiceContext,
+}));
+
+vi.mock('@/hooks/use-service-capability', () => ({
+  default: testState.useServiceCapability,
+}));
+
+vi.mock('@/hooks/use-portal-capability', () => ({
+  useUserHasPortalCapability: testState.useUserHasPortalCapability,
+}));
+
+vi.mock(
+  '@/components/service/components/ServiceListLocalStorageKeyContext',
+  () => ({
+    useServiceListLocalStorageKeyContext:
+      testState.useServiceListLocalStorageKeyContext,
+  })
+);
+
+vi.mock('@/hooks/use-service-list-local-storage', async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import('@/hooks/use-service-list-local-storage')
+  >()),
+  useServiceListLocalStorage: testState.useServiceListLocalStorage,
+}));
+
+vi.mock('@/hooks/use-scroll-position', () => ({
+  default: testState.useScrollPosition,
+}));
+
+vi.mock(
+  '@/components/service/components/header/ServiceListHeaderButtons',
+  () => ({
+    default: () => <button type="button">header-buttons</button>,
+  })
+);
+
+const buildLocalStorageState = (
+  displayMode = ServiceListDisplayModeEnum.Tab
+) => ({
+  removeLabels: testState.removeLabels,
+  displayMode,
+  setDisplayMode: testState.setDisplayMode,
+  orderBy: DocumentOrdering.Name,
+  orderMode: OrderingMode.Asc,
+  setOrderBy: testState.setOrderBy,
+  setOrderMode: testState.setOrderMode,
+  selectedFilters: testState.selectedFilters,
+  setSelectedFilters: testState.setSelectedFilters,
+});
+
+describe('ServiceList', () => {
+  beforeEach(() => {
+    testState.setDisplayMode.mockReset();
+    testState.setOrderBy.mockReset();
+    testState.setOrderMode.mockReset();
+    testState.setSelectedFilters.mockReset();
+    testState.removeLabels.mockReset();
+    testState.restore.mockReset();
+    testState.save.mockReset();
+    testState.selectedFilters = [];
+    testState.useServiceContext.mockReturnValue({
+      translationKey: 'Service.Connector',
+      serviceInstance: {
+        id: 'service-1',
+        slug: 'my-service',
+        name: 'My Service',
+        description: 'A service description',
+        service_definition: {
+          identifier: 'opencti',
+        },
+      },
+      type: 'opencti_integration',
+      setIntegrationType: vi.fn(),
+    });
+    testState.useServiceCapability.mockReturnValue(true);
+    testState.useUserHasPortalCapability.mockReturnValue(false);
+    testState.useServiceListLocalStorageKeyContext.mockReturnValue({
+      localStorageKey: ServiceListLocalStorageKey.OpenCTIIntegrationFeeds,
+    });
+    testState.useServiceListLocalStorage.mockImplementation(() =>
+      buildLocalStorageState()
+    );
+    testState.useScrollPosition.mockReturnValue({
+      restore: testState.restore,
+      save: testState.save,
+    });
+  });
+
+  it('renders hero and draft section for updatable services', () => {
+    const active = [
+      {
+        id: 'active-1',
+        slug: 'active-doc',
+        name: 'Active document',
+        type: 'opencti_integration',
+        integration_type: IntegrationType.CsvFeed,
+        short_description: 'Active description',
+        use_cases: [],
+      },
+    ] as never[];
+    const draft = [
+      {
+        id: 'draft-1',
+        slug: 'draft-doc',
+        name: 'Draft document',
+        type: 'opencti_integration',
+        short_description: 'Draft description',
+        use_cases: [],
+      },
+    ] as never[];
+
+    testRender(
+      <ServiceList
+        active={active}
+        draft={draft}
+        search=""
+        onSearchChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Service.LibraryHero.Eyebrow')).toBeInTheDocument();
+    expect(screen.getByText('My Service')).toBeInTheDocument();
+    expect(
+      screen.getByText('Service.Connector.NonActive:')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Service.Connector.Active:')).toBeInTheDocument();
+    expect(screen.getByText('Draft document')).toBeInTheDocument();
+    expect(testState.restore).toHaveBeenCalledOnce();
+  });
+
+  it('does not render draft section when user cannot upload', () => {
+    testState.useServiceCapability.mockReturnValue(false);
+    const active = [
+      {
+        id: 'active-1',
+        slug: 'active-doc',
+        name: 'Active document',
+        type: 'opencti_integration',
+        integration_type: IntegrationType.CsvFeed,
+        short_description: 'Active description',
+        use_cases: [],
+      },
+    ] as never[];
+    const draft = [
+      {
+        id: 'draft-1',
+        slug: 'draft-doc',
+        name: 'Draft document',
+        type: 'opencti_integration',
+        short_description: 'Draft description',
+        use_cases: [],
+      },
+    ] as never[];
+
+    testRender(
+      <ServiceList
+        active={active}
+        draft={draft}
+        search=""
+        onSearchChange={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText('Service.Connector.NonActive:')).toBeNull();
+    expect(screen.queryByText('Draft document')).toBeNull();
+  });
+
+  it('groups known integration types in accordion and keeps unknown types as plain lists', async () => {
+    const active = [
+      {
+        id: 'active-1',
+        slug: 'connector-doc',
+        name: 'Connector document',
+        type: 'opencti_integration',
+        integration_type: IntegrationType.Connector,
+        short_description: 'Connector description',
+        use_cases: [],
+      },
+      {
+        id: 'active-2',
+        slug: 'dashboard-doc',
+        name: 'Dashboard document',
+        type: 'opencti_custom_dashboard',
+        short_description: 'Dashboard description',
+        use_cases: [],
+      },
+    ] as never[];
+
+    const { user } = testRender(
+      <ServiceList
+        active={active}
+        draft={[]}
+        search=""
+        onSearchChange={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        `Service.OpenctiIntegrations.Type.${IntegrationType.Connector}`
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText('Dashboard document')).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', {
+        name: new RegExp(
+          `Service\\.OpenctiIntegrations\\.Type\\.${IntegrationType.Connector}`
+        ),
+      })
+    );
+
+    expect(screen.getByText('Connector document')).toBeInTheDocument();
+  });
+
+  it('forwards display mode changes to local storage setter via header actions', async () => {
+    const { user } = testRender(
+      <ServiceList
+        active={[]}
+        draft={[]}
+        search=""
+        onSearchChange={vi.fn()}
+      />
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: 'Service.List.ViewTab' })
+    );
+
+    expect(testState.setDisplayMode).toHaveBeenCalledWith(
+      ServiceListDisplayModeEnum.Tab
+    );
+  });
+});

--- a/apps/frontend/src/components/service/components/ServiceList.test.tsx
+++ b/apps/frontend/src/components/service/components/ServiceList.test.tsx
@@ -10,20 +10,6 @@ import {
 import { screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('next-intl', async (importOriginal) => {
-  const original = await importOriginal<typeof import('next-intl')>();
-  return {
-    ...original,
-    useTranslations: () => {
-      const t = ((key: string) => key) as ((key: string) => string) & {
-        has: (key: string) => boolean;
-      };
-      t.has = () => false;
-      return t;
-    },
-  };
-});
-
 const testState = vi.hoisted(() => ({
   useServiceContext: vi.fn(),
   useServiceCapability: vi.fn(),

--- a/apps/frontend/src/components/service/components/ServiceList.tsx
+++ b/apps/frontend/src/components/service/components/ServiceList.tsx
@@ -58,7 +58,11 @@ const ServiceList = ({
   ]);
 
   const { localStorageKey } = useServiceListLocalStorageKeyContext();
-  const { removeLabels } = useServiceListLocalStorage(localStorageKey);
+  const {
+    removeLabels,
+    displayMode: selectedDisplayMode,
+    setDisplayMode,
+  } = useServiceListLocalStorage(localStorageKey);
 
   const filters = {
     ...additionalFilters,
@@ -95,13 +99,16 @@ const ServiceList = ({
         {...heroSectionProps}
         showLibraryUpdate={userIsMarketingOrBypass}
       />
-      <ServiceListHeader
-        search={search}
-        onSearchChange={onSearchChange}
-        filters={filters}
-        actions={<ServiceListHeaderButtons />}
-        paginationControls={paginationControls}
-      />
+      <div className="sticky top-0 py-m z-11 relative bg-gradient-background">
+        <ServiceListHeader
+          search={search}
+          onSearchChange={onSearchChange}
+          filters={filters}
+          actions={<ServiceListHeaderButtons />}
+          paginationControls={paginationControls}
+          onDisplayModeChange={setDisplayMode}
+        />
+      </div>
       {userCanUpdate && draft.length > 0 && (
         <>
           <div className="txt-category">

--- a/apps/frontend/src/components/service/components/ServiceList.tsx
+++ b/apps/frontend/src/components/service/components/ServiceList.tsx
@@ -25,7 +25,7 @@ import useServiceCapability from '@/hooks/use-service-capability';
 import { useServiceListLocalStorage } from '@/hooks/use-service-list-local-storage';
 import { documentItem_fragment$data } from '@generated/documentItem_fragment.graphql';
 import { useTranslations } from 'next-intl';
-import { useLayoutEffect } from 'react';
+import { Fragment, useLayoutEffect } from 'react';
 
 export interface ServiceListProps {
   active: documentItem_fragment$data[];
@@ -116,6 +116,7 @@ const ServiceList = ({
           </div>
           <DocumentList
             documents={draft}
+            displayMode={selectedDisplayMode}
             connectionId={connectionId}
           />
           {active.length > 0 && (
@@ -125,26 +126,33 @@ const ServiceList = ({
       )}
 
       {Object.entries(activeByIntegrationType).map(
-        ([integrationType, documents]) =>
-          Object.values(IntegrationType).includes(
-            integrationType as IntegrationType
-          ) ? (
-            <IntegrationAccordion
-              key={integrationType}
-              integrationType={integrationType}
-              count={documents.length}>
+        ([integrationType, documents]) => (
+          <Fragment key={integrationType}>
+            {Object.values(IntegrationType).includes(
+              integrationType as IntegrationType
+            ) ? (
+              <>
+                <IntegrationAccordion
+                  key={integrationType}
+                  integrationType={integrationType}
+                  count={documents.length}>
+                  <DocumentList
+                    documents={documents}
+                    displayMode={selectedDisplayMode}
+                    connectionId={connectionId}
+                  />
+                </IntegrationAccordion>
+              </>
+            ) : (
               <DocumentList
+                displayMode={selectedDisplayMode}
+                key={integrationType}
                 documents={documents}
                 connectionId={connectionId}
               />
-            </IntegrationAccordion>
-          ) : (
-            <DocumentList
-              key={integrationType}
-              documents={documents}
-              connectionId={connectionId}
-            />
-          )
+            )}
+          </Fragment>
+        )
       )}
     </div>
   );

--- a/apps/frontend/src/components/service/components/ServiceList.tsx
+++ b/apps/frontend/src/components/service/components/ServiceList.tsx
@@ -131,22 +131,18 @@ const ServiceList = ({
             {Object.values(IntegrationType).includes(
               integrationType as IntegrationType
             ) ? (
-              <>
-                <IntegrationAccordion
-                  key={integrationType}
-                  integrationType={integrationType}
-                  count={documents.length}>
-                  <DocumentList
-                    documents={documents}
-                    displayMode={selectedDisplayMode}
-                    connectionId={connectionId}
-                  />
-                </IntegrationAccordion>
-              </>
+              <IntegrationAccordion
+                integrationType={integrationType}
+                count={documents.length}>
+                <DocumentList
+                  documents={documents}
+                  displayMode={selectedDisplayMode}
+                  connectionId={connectionId}
+                />
+              </IntegrationAccordion>
             ) : (
               <DocumentList
                 displayMode={selectedDisplayMode}
-                key={integrationType}
                 documents={documents}
                 connectionId={connectionId}
               />

--- a/apps/frontend/src/components/service/components/header/ServiceListHeader.test.tsx
+++ b/apps/frontend/src/components/service/components/header/ServiceListHeader.test.tsx
@@ -1,5 +1,5 @@
 import {
-  ServiceListDisplayModeEnum,
+  ServiceListDisplayMode,
   ServiceListFilterKey,
   ServiceListHeader,
 } from '@/components/service/components/header/ServiceListHeader';
@@ -33,9 +33,7 @@ vi.mock('@/hooks/use-service-list-local-storage', async (importOriginal) => ({
   useServiceListLocalStorage: testState.useServiceListLocalStorage,
 }));
 
-const buildLocalStorageState = (
-  displayMode = ServiceListDisplayModeEnum.List
-) => ({
+const buildLocalStorageState = (displayMode = ServiceListDisplayMode.List) => ({
   orderBy: DocumentOrdering.Name,
   orderMode: OrderingMode.Asc,
   setOrderBy: testState.setOrderBy,
@@ -99,9 +97,9 @@ describe('ServiceListHeader', () => {
   });
 
   it.each`
-    initialDisplayMode                 | clickedLabel               | expectedMode
-    ${ServiceListDisplayModeEnum.List} | ${'Service.List.ViewTab'}  | ${ServiceListDisplayModeEnum.Tab}
-    ${ServiceListDisplayModeEnum.Tab}  | ${'Service.List.ViewList'} | ${ServiceListDisplayModeEnum.List}
+    initialDisplayMode             | clickedLabel               | expectedMode
+    ${ServiceListDisplayMode.List} | ${'Service.List.ViewTab'}  | ${ServiceListDisplayMode.Tab}
+    ${ServiceListDisplayMode.Tab}  | ${'Service.List.ViewList'} | ${ServiceListDisplayMode.List}
   `(
     'changes display mode from $initialDisplayMode when clicking $clickedLabel',
     async ({ initialDisplayMode, clickedLabel, expectedMode }) => {
@@ -120,9 +118,9 @@ describe('ServiceListHeader', () => {
   );
 
   it.each`
-    initialDisplayMode                 | expectedTabClass           | expectedListClass
-    ${ServiceListDisplayModeEnum.Tab}  | ${'text-primary'}          | ${'text-muted-foreground'}
-    ${ServiceListDisplayModeEnum.List} | ${'text-muted-foreground'} | ${'text-primary'}
+    initialDisplayMode             | expectedTabClass           | expectedListClass
+    ${ServiceListDisplayMode.Tab}  | ${'text-primary'}          | ${'text-muted-foreground'}
+    ${ServiceListDisplayMode.List} | ${'text-muted-foreground'} | ${'text-primary'}
   `(
     'applies selected color classes for mode=$initialDisplayMode',
     ({ initialDisplayMode, expectedTabClass, expectedListClass }) => {

--- a/apps/frontend/src/components/service/components/header/ServiceListHeader.test.tsx
+++ b/apps/frontend/src/components/service/components/header/ServiceListHeader.test.tsx
@@ -1,0 +1,179 @@
+import {
+  ServiceListDisplayModeEnum,
+  ServiceListFilterKey,
+  ServiceListHeader,
+} from '@/components/service/components/header/ServiceListHeader';
+import { AppServiceListLocalStorageKeyContext } from '@/components/service/components/ServiceListLocalStorageKeyContext';
+import { ServiceListLocalStorageKey } from '@/hooks/use-service-list-local-storage';
+import testRender from '@/utils/test/test-render';
+import { DocumentOrdering, OrderingMode } from '@graphql/generated';
+import { screen } from '@testing-library/react';
+import { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+const testState = vi.hoisted(() => ({
+  useServiceListLocalStorage: vi.fn(),
+  setOrderBy: vi.fn(),
+  setOrderMode: vi.fn(),
+  setDisplayMode: vi.fn(),
+  selectedFilters: [] as ServiceListFilterKey[],
+}));
+
+vi.mock('@/utils/debounce', () => ({
+  debounceHandleInput:
+    (callback: (value: string) => void) =>
+    (event: { target: { value: string } }) =>
+      callback(event.target.value),
+}));
+
+vi.mock('@/hooks/use-service-list-local-storage', async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import('@/hooks/use-service-list-local-storage')
+  >()),
+  useServiceListLocalStorage: testState.useServiceListLocalStorage,
+}));
+
+const buildLocalStorageState = (
+  displayMode = ServiceListDisplayModeEnum.List
+) => ({
+  orderBy: DocumentOrdering.Name,
+  orderMode: OrderingMode.Asc,
+  setOrderBy: testState.setOrderBy,
+  setOrderMode: testState.setOrderMode,
+  displayMode,
+  setDisplayMode: testState.setDisplayMode,
+  selectedFilters: testState.selectedFilters,
+  setSelectedFilters: vi.fn(),
+});
+
+const renderHeader = (
+  props?: Partial<ComponentProps<typeof ServiceListHeader>>
+) =>
+  testRender(
+    <AppServiceListLocalStorageKeyContext
+      localStorageKey={ServiceListLocalStorageKey.OpenCTIIntegrationFeeds}>
+      <ServiceListHeader
+        search=""
+        onSearchChange={vi.fn()}
+        filters={{}}
+        {...props}
+      />
+    </AppServiceListLocalStorageKeyContext>
+  );
+
+describe('ServiceListHeader', () => {
+  it('renders search, actions and pagination controls', () => {
+    testState.selectedFilters = [];
+    testState.useServiceListLocalStorage.mockReturnValue(
+      buildLocalStorageState()
+    );
+
+    renderHeader({
+      actions: <button type="button">extra-action</button>,
+      paginationControls: <div>pagination-controls</div>,
+    });
+
+    expect(
+      screen.getByPlaceholderText('GenericActions.Search')
+    ).toBeInTheDocument();
+    expect(screen.getByText('pagination-controls')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'extra-action' })
+    ).toBeInTheDocument();
+  });
+
+  it('calls onSearchChange when typing in search input', async () => {
+    testState.selectedFilters = [];
+    testState.useServiceListLocalStorage.mockReturnValue(
+      buildLocalStorageState()
+    );
+    const onSearchChange = vi.fn();
+    const { user } = renderHeader({ onSearchChange });
+
+    await user.type(
+      screen.getByPlaceholderText('GenericActions.Search'),
+      'opencti'
+    );
+
+    expect(onSearchChange).toHaveBeenLastCalledWith('opencti');
+  });
+
+  it.each`
+    initialDisplayMode                 | clickedLabel               | expectedMode
+    ${ServiceListDisplayModeEnum.List} | ${'Service.List.ViewTab'}  | ${ServiceListDisplayModeEnum.Tab}
+    ${ServiceListDisplayModeEnum.Tab}  | ${'Service.List.ViewList'} | ${ServiceListDisplayModeEnum.List}
+  `(
+    'changes display mode from $initialDisplayMode when clicking $clickedLabel',
+    async ({ initialDisplayMode, clickedLabel, expectedMode }) => {
+      testState.selectedFilters = [];
+      testState.useServiceListLocalStorage.mockReturnValue(
+        buildLocalStorageState(initialDisplayMode)
+      );
+      const onDisplayModeChange = vi.fn();
+      const { user } = renderHeader({ onDisplayModeChange });
+
+      await user.click(screen.getByRole('button', { name: clickedLabel }));
+
+      expect(testState.setDisplayMode).toHaveBeenCalledWith(expectedMode);
+      expect(onDisplayModeChange).toHaveBeenCalledWith(expectedMode);
+    }
+  );
+
+  it.each`
+    initialDisplayMode                 | expectedTabClass           | expectedListClass
+    ${ServiceListDisplayModeEnum.Tab}  | ${'text-primary'}          | ${'text-muted-foreground'}
+    ${ServiceListDisplayModeEnum.List} | ${'text-muted-foreground'} | ${'text-primary'}
+  `(
+    'applies selected color classes for mode=$initialDisplayMode',
+    ({ initialDisplayMode, expectedTabClass, expectedListClass }) => {
+      testState.selectedFilters = [];
+      testState.useServiceListLocalStorage.mockReturnValue(
+        buildLocalStorageState(initialDisplayMode)
+      );
+
+      renderHeader();
+
+      const tabIcon = screen
+        .getByRole('button', { name: 'Service.List.ViewTab' })
+        .querySelector('svg');
+      const listIcon = screen
+        .getByRole('button', { name: 'Service.List.ViewList' })
+        .querySelector('svg');
+
+      expect(tabIcon).toHaveClass(expectedTabClass);
+      expect(listIcon).toHaveClass(expectedListClass);
+    }
+  );
+
+  it('renders selected filter nodes in filter section', () => {
+    testState.selectedFilters = [ServiceListFilterKey.Label];
+    testState.useServiceListLocalStorage.mockReturnValue(
+      buildLocalStorageState()
+    );
+
+    renderHeader({
+      filters: {
+        [ServiceListFilterKey.Label]: {
+          node: <span>label-filter</span>,
+          reset: vi.fn(),
+        },
+      },
+    });
+
+    expect(screen.getByText('label-filter')).toBeInTheDocument();
+  });
+
+  it('toggles ordering mode when clicking sort direction button', async () => {
+    testState.selectedFilters = [];
+    testState.useServiceListLocalStorage.mockReturnValue(
+      buildLocalStorageState()
+    );
+    const { user } = renderHeader();
+
+    await user.click(
+      screen.getByRole('button', { name: 'SortControls.SortBy asc' })
+    );
+
+    expect(testState.setOrderMode).toHaveBeenCalledWith(OrderingMode.Desc);
+  });
+});

--- a/apps/frontend/src/components/service/components/header/ServiceListHeader.tsx
+++ b/apps/frontend/src/components/service/components/header/ServiceListHeader.tsx
@@ -6,6 +6,8 @@ import { SortControls } from '@/components/ui/SortControls';
 import { useServiceListLocalStorage } from '@/hooks/use-service-list-local-storage';
 import { cn } from '@/lib/utils';
 import { debounceHandleInput } from '@/utils/debounce';
+import { CalendarViewMonthIcon, ListViewIcon } from '@filigran/icon';
+import { Separator } from '@filigran/ui/clients';
 import { DocumentOrdering } from '@graphql/generated';
 import { useTranslations } from 'next-intl';
 import React from 'react';
@@ -30,6 +32,12 @@ export type ServiceListFilterMap = Partial<
   Record<ServiceListFilterKey, ServiceListFilter>
 >;
 
+export enum ServiceListDisplayModeEnum {
+  Tab = 'tab',
+  List = 'list',
+}
+export type ServiceListDisplayMode = ServiceListDisplayModeEnum;
+
 interface ServiceListHeaderProps {
   search: string;
   onSearchChange: (v: string) => void;
@@ -37,6 +45,7 @@ interface ServiceListHeaderProps {
   paginationControls?: React.ReactNode;
   actions?: React.ReactNode;
   className?: string;
+  onDisplayModeChange?: (mode: ServiceListDisplayMode) => void;
 }
 
 export const ServiceListHeader = ({
@@ -46,12 +55,23 @@ export const ServiceListHeader = ({
   paginationControls,
   actions,
   className,
+  onDisplayModeChange,
 }: ServiceListHeaderProps) => {
   const t = useTranslations();
 
   const { localStorageKey } = useServiceListLocalStorageKeyContext();
-  const { orderBy, orderMode, setOrderBy, setOrderMode } =
-    useServiceListLocalStorage(localStorageKey);
+  const {
+    orderBy,
+    orderMode,
+    setOrderBy,
+    setOrderMode,
+    displayMode: storedDisplayMode,
+    setDisplayMode: setStoredDisplayMode,
+  } = useServiceListLocalStorage(localStorageKey);
+  const handleDisplayModeChange = (mode: ServiceListDisplayMode) => {
+    setStoredDisplayMode(mode);
+    onDisplayModeChange?.(mode);
+  };
 
   const sortOptions = [
     DocumentOrdering.Name,
@@ -100,10 +120,54 @@ export const ServiceListHeader = ({
             </div>
           </div>
           {paginationControls && (
-            <div className="max-sm:w-full max-sm:[&>div]:w-full max-sm:[&>div>*:nth-child(2)]:flex-1">
+            <div className="ml-auto max-sm:w-full max-sm:[&>div]:w-full max-sm:[&>div>*:nth-child(2)]:flex-1">
               {paginationControls}
             </div>
           )}
+          <div className="p-s border hover:cursor-pointer flex items-center align-middle gap-s">
+            <button
+              type="button"
+              onClick={() =>
+                handleDisplayModeChange(ServiceListDisplayModeEnum.Tab)
+              }
+              className="hover:cursor-pointer flex items-center"
+              aria-pressed={
+                storedDisplayMode === ServiceListDisplayModeEnum.Tab
+              }
+              aria-label={t('Service.List.ViewTab')}>
+              <CalendarViewMonthIcon
+                className={cn(
+                  'h-5 w-5',
+                  storedDisplayMode === ServiceListDisplayModeEnum.Tab
+                    ? 'text-primary'
+                    : 'text-muted-foreground'
+                )}
+              />
+            </button>
+            <Separator
+              orientation="vertical"
+              className="h-5 w-px bg-border"
+            />
+            <button
+              type="button"
+              onClick={() =>
+                handleDisplayModeChange(ServiceListDisplayModeEnum.List)
+              }
+              className="hover:cursor-pointer flex items-center"
+              aria-pressed={
+                storedDisplayMode === ServiceListDisplayModeEnum.List
+              }
+              aria-label={t('Service.List.ViewList')}>
+              <ListViewIcon
+                className={cn(
+                  'h-4 w-4',
+                  storedDisplayMode === ServiceListDisplayModeEnum.List
+                    ? 'text-primary'
+                    : 'text-muted-foreground'
+                )}
+              />
+            </button>
+          </div>
         </div>
 
         {actions && (

--- a/apps/frontend/src/components/service/components/header/ServiceListHeader.tsx
+++ b/apps/frontend/src/components/service/components/header/ServiceListHeader.tsx
@@ -32,11 +32,10 @@ export type ServiceListFilterMap = Partial<
   Record<ServiceListFilterKey, ServiceListFilter>
 >;
 
-export enum ServiceListDisplayModeEnum {
+export enum ServiceListDisplayMode {
   Tab = 'tab',
   List = 'list',
 }
-export type ServiceListDisplayMode = ServiceListDisplayModeEnum;
 
 interface ServiceListHeaderProps {
   search: string;
@@ -135,17 +134,15 @@ export const ServiceListHeader = ({
               <button
                 type="button"
                 onClick={() =>
-                  handleDisplayModeChange(ServiceListDisplayModeEnum.Tab)
+                  handleDisplayModeChange(ServiceListDisplayMode.Tab)
                 }
                 className="hover:cursor-pointer flex items-center"
-                aria-pressed={
-                  storedDisplayMode === ServiceListDisplayModeEnum.Tab
-                }
+                aria-pressed={storedDisplayMode === ServiceListDisplayMode.Tab}
                 aria-label={t('Service.List.ViewTab')}>
                 <CalendarViewMonthIcon
                   className={cn(
                     'h-5 w-5',
-                    storedDisplayMode === ServiceListDisplayModeEnum.Tab
+                    storedDisplayMode === ServiceListDisplayMode.Tab
                       ? 'text-primary'
                       : 'text-muted-foreground'
                   )}
@@ -158,17 +155,15 @@ export const ServiceListHeader = ({
               <button
                 type="button"
                 onClick={() =>
-                  handleDisplayModeChange(ServiceListDisplayModeEnum.List)
+                  handleDisplayModeChange(ServiceListDisplayMode.List)
                 }
                 className="hover:cursor-pointer flex items-center"
-                aria-pressed={
-                  storedDisplayMode === ServiceListDisplayModeEnum.List
-                }
+                aria-pressed={storedDisplayMode === ServiceListDisplayMode.List}
                 aria-label={t('Service.List.ViewList')}>
                 <ListViewIcon
                   className={cn(
                     'h-4 w-4',
-                    storedDisplayMode === ServiceListDisplayModeEnum.List
+                    storedDisplayMode === ServiceListDisplayMode.List
                       ? 'text-primary'
                       : 'text-muted-foreground'
                   )}

--- a/apps/frontend/src/components/service/components/header/ServiceListHeader.tsx
+++ b/apps/frontend/src/components/service/components/header/ServiceListHeader.tsx
@@ -119,54 +119,62 @@ export const ServiceListHeader = ({
               {sortControls}
             </div>
           </div>
-          {paginationControls && (
-            <div className="ml-auto max-sm:w-full max-sm:[&>div]:w-full max-sm:[&>div>*:nth-child(2)]:flex-1">
-              {paginationControls}
-            </div>
-          )}
-          <div className="p-s border hover:cursor-pointer flex items-center align-middle gap-s">
-            <button
-              type="button"
-              onClick={() =>
-                handleDisplayModeChange(ServiceListDisplayModeEnum.Tab)
-              }
-              className="hover:cursor-pointer flex items-center"
-              aria-pressed={
-                storedDisplayMode === ServiceListDisplayModeEnum.Tab
-              }
-              aria-label={t('Service.List.ViewTab')}>
-              <CalendarViewMonthIcon
-                className={cn(
-                  'h-5 w-5',
+          <div
+            className={cn(
+              'flex items-center gap-s max-sm:w-full',
+              paginationControls
+                ? 'max-sm:justify-between sm:ml-auto'
+                : 'ml-auto'
+            )}>
+            {paginationControls && (
+              <div className="min-w-0 flex-1 max-sm:[&>div]:w-full max-sm:[&>div>*:nth-child(2)]:flex-1">
+                {paginationControls}
+              </div>
+            )}
+            <div className="p-s border hover:cursor-pointer flex items-center align-middle gap-s">
+              <button
+                type="button"
+                onClick={() =>
+                  handleDisplayModeChange(ServiceListDisplayModeEnum.Tab)
+                }
+                className="hover:cursor-pointer flex items-center"
+                aria-pressed={
                   storedDisplayMode === ServiceListDisplayModeEnum.Tab
-                    ? 'text-primary'
-                    : 'text-muted-foreground'
-                )}
+                }
+                aria-label={t('Service.List.ViewTab')}>
+                <CalendarViewMonthIcon
+                  className={cn(
+                    'h-5 w-5',
+                    storedDisplayMode === ServiceListDisplayModeEnum.Tab
+                      ? 'text-primary'
+                      : 'text-muted-foreground'
+                  )}
+                />
+              </button>
+              <Separator
+                orientation="vertical"
+                className="h-5 w-px bg-border"
               />
-            </button>
-            <Separator
-              orientation="vertical"
-              className="h-5 w-px bg-border"
-            />
-            <button
-              type="button"
-              onClick={() =>
-                handleDisplayModeChange(ServiceListDisplayModeEnum.List)
-              }
-              className="hover:cursor-pointer flex items-center"
-              aria-pressed={
-                storedDisplayMode === ServiceListDisplayModeEnum.List
-              }
-              aria-label={t('Service.List.ViewList')}>
-              <ListViewIcon
-                className={cn(
-                  'h-4 w-4',
+              <button
+                type="button"
+                onClick={() =>
+                  handleDisplayModeChange(ServiceListDisplayModeEnum.List)
+                }
+                className="hover:cursor-pointer flex items-center"
+                aria-pressed={
                   storedDisplayMode === ServiceListDisplayModeEnum.List
-                    ? 'text-primary'
-                    : 'text-muted-foreground'
-                )}
-              />
-            </button>
+                }
+                aria-label={t('Service.List.ViewList')}>
+                <ListViewIcon
+                  className={cn(
+                    'h-4 w-4',
+                    storedDisplayMode === ServiceListDisplayModeEnum.List
+                      ? 'text-primary'
+                      : 'text-muted-foreground'
+                  )}
+                />
+              </button>
+            </div>
           </div>
         </div>
 

--- a/apps/frontend/src/components/service/document/PublicDocumentsList.test.tsx
+++ b/apps/frontend/src/components/service/document/PublicDocumentsList.test.tsx
@@ -1,9 +1,12 @@
-import { ServiceListDisplayModeEnum } from '@/components/service/components/header/ServiceListHeader';
+import { ServiceListDisplayMode } from '@/components/service/components/header/ServiceListHeader';
 import PublicDocumentsList from '@/components/service/document/PublicDocumentsList';
 import { ServiceListLocalStorageKey } from '@/hooks/use-service-list-local-storage';
 import testRender from '@/utils/test/test-render';
+import { publicDocumentsQuery } from '@generated/publicDocumentsQuery.graphql';
+import { seoServiceInstanceFragment$data } from '@generated/seoServiceInstanceFragment.graphql';
 import { DocumentOrdering, OrderingMode } from '@graphql/generated';
 import { screen } from '@testing-library/react';
+import { PreloadedQuery } from 'react-relay';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const testState = vi.hoisted(() => ({
@@ -65,8 +68,8 @@ describe('PublicDocumentsList', () => {
   const serviceInstance = {
     id: 'service-1',
     slug: 'my-service',
-  } as never;
-  const queryRef = {} as never;
+  } as Partial<seoServiceInstanceFragment$data>;
+  const queryRef = {} as PreloadedQuery<publicDocumentsQuery>;
 
   beforeEach(() => {
     testState.refetch.mockReset();
@@ -84,7 +87,7 @@ describe('PublicDocumentsList', () => {
       setSearch: testState.setSearch,
       pageSize: 10,
       setPageSize: testState.setPageSize,
-      displayMode: ServiceListDisplayModeEnum.List,
+      displayMode: ServiceListDisplayMode.List,
       setDisplayMode: testState.setDisplayMode,
       orderBy: DocumentOrdering.Name,
       orderMode: OrderingMode.Asc,
@@ -165,7 +168,7 @@ describe('PublicDocumentsList', () => {
 
     expect(testState.setSearch).toHaveBeenCalledWith('search-updated');
     expect(testState.setDisplayMode).toHaveBeenCalledWith(
-      ServiceListDisplayModeEnum.Tab
+      ServiceListDisplayMode.Tab
     );
   });
 

--- a/apps/frontend/src/components/service/document/PublicDocumentsList.test.tsx
+++ b/apps/frontend/src/components/service/document/PublicDocumentsList.test.tsx
@@ -1,0 +1,190 @@
+import { ServiceListDisplayModeEnum } from '@/components/service/components/header/ServiceListHeader';
+import PublicDocumentsList from '@/components/service/document/PublicDocumentsList';
+import { ServiceListLocalStorageKey } from '@/hooks/use-service-list-local-storage';
+import testRender from '@/utils/test/test-render';
+import { DocumentOrdering, OrderingMode } from '@graphql/generated';
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testState = vi.hoisted(() => ({
+  usePreloadedQuery: vi.fn(),
+  useRefetchableFragment: vi.fn(),
+  readInlineData: vi.fn(),
+  useShareableResourceMapping: vi.fn(),
+  useServiceListLocalStorage: vi.fn(),
+  useScrollPosition: vi.fn(),
+  refetch: vi.fn(),
+  setSearch: vi.fn(),
+  setPageSize: vi.fn(),
+  setDisplayMode: vi.fn(),
+  restore: vi.fn(),
+}));
+
+vi.mock('@/utils/shareable-resources/use-shareable-resource-mapping', () => ({
+  useShareableResourceMapping: testState.useShareableResourceMapping,
+}));
+
+vi.mock('@/hooks/use-service-list-local-storage', async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import('@/hooks/use-service-list-local-storage')
+  >()),
+  useServiceListLocalStorage: testState.useServiceListLocalStorage,
+}));
+
+vi.mock('@/hooks/use-scroll-position', () => ({
+  default: testState.useScrollPosition,
+}));
+
+vi.mock('@/hooks/use-service-list-filters', () => ({
+  useServiceListFilters: () => ({
+    selectedFilters: [],
+    addFilter: vi.fn(),
+    removeFilter: vi.fn(),
+  }),
+}));
+
+vi.mock('@/utils/debounce', () => ({
+  debounceHandleInput:
+    (callback: (value: string) => void) =>
+    (event: { target: { value: string } }) =>
+      callback(event.target.value),
+}));
+
+vi.mock('react-relay', async (importOriginal) => {
+  const original = await importOriginal<typeof import('react-relay')>();
+  return {
+    ...original,
+    usePreloadedQuery: testState.usePreloadedQuery,
+    useRefetchableFragment: testState.useRefetchableFragment,
+    readInlineData: testState.readInlineData,
+    useMutation: () => [vi.fn(), false],
+  };
+});
+
+describe('PublicDocumentsList', () => {
+  const serviceInstance = {
+    id: 'service-1',
+    slug: 'my-service',
+  } as never;
+  const queryRef = {} as never;
+
+  beforeEach(() => {
+    testState.refetch.mockReset();
+    testState.setSearch.mockReset();
+    testState.setPageSize.mockReset();
+    testState.setDisplayMode.mockReset();
+    testState.restore.mockReset();
+
+    testState.useShareableResourceMapping.mockReturnValue({
+      localStorageKey: ServiceListLocalStorageKey.OpenCTIIntegrationFeeds,
+      filters: {},
+    });
+    testState.useServiceListLocalStorage.mockReturnValue({
+      search: 'initial-search',
+      setSearch: testState.setSearch,
+      pageSize: 10,
+      setPageSize: testState.setPageSize,
+      displayMode: ServiceListDisplayModeEnum.List,
+      setDisplayMode: testState.setDisplayMode,
+      orderBy: DocumentOrdering.Name,
+      orderMode: OrderingMode.Asc,
+      setOrderBy: vi.fn(),
+      setOrderMode: vi.fn(),
+      selectedFilters: [],
+      setSelectedFilters: vi.fn(),
+    });
+    testState.useScrollPosition.mockReturnValue({
+      restore: testState.restore,
+    });
+
+    testState.usePreloadedQuery.mockReturnValue({});
+    testState.useRefetchableFragment.mockReturnValue([
+      {
+        publicDocuments: {
+          totalCount: 30,
+          edges: [
+            {
+              node: {
+                id: 'doc-1',
+                slug: 'doc-1',
+                name: 'Doc 1',
+                type: 'opencti_custom_dashboard',
+                short_description: 'description 1',
+                use_cases: [],
+              },
+            },
+            {
+              node: {
+                id: 'doc-2',
+                slug: 'doc-2',
+                name: 'Doc 2',
+                type: 'opencti_custom_dashboard',
+                short_description: 'description 2',
+                use_cases: [],
+              },
+            },
+          ],
+        },
+      },
+      testState.refetch,
+    ]);
+    testState.readInlineData.mockImplementation(
+      (_fragment: unknown, node: unknown) => node
+    );
+  });
+
+  it('renders public documents list from relay data', () => {
+    testRender(
+      <PublicDocumentsList
+        queryRef={queryRef}
+        serviceInstance={serviceInstance}
+        baseUrl="https://xtm.local"
+      />
+    );
+
+    expect(testState.restore).toHaveBeenCalledOnce();
+    expect(screen.getByText('Doc 1')).toBeInTheDocument();
+    expect(screen.getByText('Doc 2')).toBeInTheDocument();
+  });
+
+  it('forwards search and display mode changes from header to local storage setters', async () => {
+    const { user } = testRender(
+      <PublicDocumentsList
+        queryRef={queryRef}
+        serviceInstance={serviceInstance}
+        baseUrl="https://xtm.local"
+      />
+    );
+
+    const searchInput = screen.getByPlaceholderText('GenericActions.Search');
+    await user.clear(searchInput);
+    await user.type(searchInput, 'search-updated');
+    await user.click(
+      screen.getByRole('button', { name: 'Service.List.ViewTab' })
+    );
+
+    expect(testState.setSearch).toHaveBeenCalledWith('search-updated');
+    expect(testState.setDisplayMode).toHaveBeenCalledWith(
+      ServiceListDisplayModeEnum.Tab
+    );
+  });
+
+  it('refetches with encoded cursor when going to next page', async () => {
+    const { user } = testRender(
+      <PublicDocumentsList
+        queryRef={queryRef}
+        serviceInstance={serviceInstance}
+        baseUrl="https://xtm.local"
+      />
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: 'GenericActions.Paginate.NextPage' })
+    );
+
+    expect(testState.refetch).toHaveBeenCalledWith({
+      count: 10,
+      cursor: btoa('10'),
+    });
+  });
+});

--- a/apps/frontend/src/components/service/document/PublicDocumentsList.tsx
+++ b/apps/frontend/src/components/service/document/PublicDocumentsList.tsx
@@ -61,8 +61,14 @@ const PublicDocumentsList = ({
     serviceInstance.slug as ServiceSlug
   );
 
-  const { search, setSearch, pageSize, setPageSize } =
-    useServiceListLocalStorage(localStorageKey);
+  const {
+    search,
+    setSearch,
+    pageSize,
+    setPageSize,
+    displayMode: selectedDisplayMode,
+    setDisplayMode,
+  } = useServiceListLocalStorage(localStorageKey);
 
   const { restore } = useScrollPosition();
 
@@ -80,22 +86,26 @@ const PublicDocumentsList = ({
 
   return (
     <AppServiceListLocalStorageKeyContext localStorageKey={localStorageKey}>
-      <ServiceListHeader
-        search={search}
-        onSearchChange={setSearch}
-        filters={filters}
-        className="mb-3"
-        paginationControls={
-          <PaginationControls
-            totalCount={data.publicDocuments.totalCount}
-            pageSize={pageSize}
-            pageIndex={pagination.pageIndex}
-            onPaginationChange={onPaginationChange}
-            onSetPageSize={setPageSize}
-          />
-        }
-      />
+      <div className="sticky top-0 py-m z-100 relative bg-gradient-background">
+        <ServiceListHeader
+          search={search}
+          onSearchChange={setSearch}
+          filters={filters}
+          className="mb-3"
+          onDisplayModeChange={setDisplayMode}
+          paginationControls={
+            <PaginationControls
+              totalCount={data.publicDocuments.totalCount}
+              pageSize={pageSize}
+              pageIndex={pagination.pageIndex}
+              onPaginationChange={onPaginationChange}
+              onSetPageSize={setPageSize}
+            />
+          }
+        />
+      </div>
       <PublicShareableResourceList
+        displayMode={selectedDisplayMode}
         documents={documents}
         serviceInstance={serviceInstance}
         baseUrl={baseUrl}

--- a/apps/frontend/src/components/ui/UserDisplay.test.tsx
+++ b/apps/frontend/src/components/ui/UserDisplay.test.tsx
@@ -3,6 +3,14 @@ import { screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { UserDisplay } from './UserDisplay';
 
+const uploaderWithPicture = {
+  id: 'user-with-picture',
+  first_name: 'jane',
+  last_name: 'doe',
+  email: 'jane@filigran.io',
+  picture: 'https://filigran.io/avatar.png',
+};
+
 describe('UserDisplay', () => {
   it('renders the uploader full name when available', () => {
     testRender(
@@ -69,5 +77,31 @@ describe('UserDisplay', () => {
 
     const nameText = screen.getByText('Jane Doe');
     expect(nameText).not.toHaveClass('italic');
+  });
+
+  it('should render the avatar container when displayPicture is true', () => {
+    // Given
+    testRender(
+      <UserDisplay
+        uploader={uploaderWithPicture}
+        displayPicture
+      />
+    );
+
+    // Then
+    expect(screen.getByRole('img', { hidden: true })).toBeInTheDocument();
+  });
+
+  it('should not render the avatar container when displayPicture is false', () => {
+    // Given
+    testRender(
+      <UserDisplay
+        uploader={uploaderWithPicture}
+        displayPicture={false}
+      />
+    );
+
+    // Then
+    expect(screen.queryByRole('img', { hidden: true })).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/ui/UserDisplay.tsx
+++ b/apps/frontend/src/components/ui/UserDisplay.tsx
@@ -19,12 +19,14 @@ interface UserDisplayProps {
     | undefined;
   className?: string;
   withTooltip?: boolean;
+  displayPicture?: boolean;
 }
 
 export const UserDisplay = ({
   uploader,
   className,
   withTooltip = false,
+  displayPicture = true,
 }: UserDisplayProps) => {
   const t = useTranslations('UserDisplay');
   const formattedName = formatPersonNames(uploader);
@@ -47,9 +49,11 @@ export const UserDisplay = ({
 
   return (
     <>
-      <div className="size-8 shrink-0 [&_img]:object-cover">
-        <Avatar src={uploader?.picture ?? ''} />
-      </div>
+      {displayPicture && (
+        <div className="size-8 shrink-0 [&_img]:object-cover">
+          <Avatar src={uploader?.picture ?? ''} />
+        </div>
+      )}
       {withTooltip ? (
         <TooltipProvider>
           <Tooltip>

--- a/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.test.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.test.tsx
@@ -7,30 +7,31 @@ import { describe, expect, it } from 'vitest';
 import { PublicShareableDocumentList } from './PublicShareableDocumentList';
 
 describe('PublicShareableDocumentList', () => {
-  it('renders one public card per document with expected public URLs', () => {
-    const serviceInstance = {
-      id: 'service-1',
-      slug: 'my-service',
-    } as seoServiceInstanceFragment$data;
-    const documents = [
-      {
-        id: 'doc-1',
-        slug: 'connector-doc',
-        name: 'Connector document',
-        type: 'opencti_custom_dashboard',
-        short_description: 'Connector description',
-        use_cases: [],
-      },
-      {
-        id: 'doc-2',
-        slug: 'dashboard-doc',
-        name: 'Dashboard document',
-        type: 'opencti_custom_dashboard',
-        short_description: 'Dashboard description',
-        use_cases: [],
-      },
-    ] as publicDocumentListItemFragment$data[];
+  const serviceInstance = {
+    id: 'service-1',
+    slug: 'my-service',
+  } as seoServiceInstanceFragment$data;
 
+  const documents = [
+    {
+      id: 'doc-1',
+      slug: 'connector-doc',
+      name: 'Connector document',
+      type: 'opencti_custom_dashboard',
+      short_description: 'Connector description',
+      use_cases: [],
+    },
+    {
+      id: 'doc-2',
+      slug: 'dashboard-doc',
+      name: 'Dashboard document',
+      type: 'opencti_custom_dashboard',
+      short_description: 'Dashboard description',
+      use_cases: [],
+    },
+  ] as publicDocumentListItemFragment$data[];
+
+  it('renders one public card per document with expected public URLs in tab mode', () => {
     testRender(
       <PublicShareableDocumentList
         documents={documents}
@@ -58,5 +59,25 @@ describe('PublicShareableDocumentList', () => {
       'href',
       '/en/cybersecurity-solutions/my-service/dashboard-doc'
     );
+  });
+
+  it('renders list mode without public detail card links', () => {
+    testRender(
+      <PublicShareableDocumentList
+        documents={documents}
+        serviceInstance={serviceInstance}
+        baseUrl="https://xtm.local"
+        displayMode={ServiceListDisplayModeEnum.List}
+      />
+    );
+
+    expect(screen.getByText('Connector document')).toBeInTheDocument();
+    expect(screen.getByText('Dashboard document')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Connector document' })
+    ).toBeNull();
+    expect(
+      screen.queryByRole('link', { name: 'Dashboard document' })
+    ).toBeNull();
   });
 });

--- a/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.test.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.test.tsx
@@ -1,4 +1,4 @@
-import { ServiceListDisplayModeEnum } from '@/components/service/components/header/ServiceListHeader';
+import { ServiceListDisplayMode } from '@/components/service/components/header/ServiceListHeader';
 import testRender from '@/utils/test/test-render';
 import { publicDocumentListItemFragment$data } from '@generated/publicDocumentListItemFragment.graphql';
 import { seoServiceInstanceFragment$data } from '@generated/seoServiceInstanceFragment.graphql';
@@ -66,7 +66,7 @@ describe('PublicShareableDocumentList', () => {
         documents={documents}
         serviceInstance={serviceInstance}
         baseUrl={BaseUrl}
-        displayMode={ServiceListDisplayModeEnum.Tab}
+        displayMode={ServiceListDisplayMode.Tab}
       />
     );
 
@@ -98,7 +98,7 @@ describe('PublicShareableDocumentList', () => {
         documents={documents}
         serviceInstance={serviceInstance}
         baseUrl={BaseUrl}
-        displayMode={ServiceListDisplayModeEnum.List}
+        displayMode={ServiceListDisplayMode.List}
       />
     );
 
@@ -116,7 +116,7 @@ describe('PublicShareableDocumentList', () => {
         documents={documents}
         serviceInstance={serviceInstance}
         baseUrl={BaseUrl}
-        displayMode={ServiceListDisplayModeEnum.List}
+        displayMode={ServiceListDisplayMode.List}
       />
     );
 
@@ -136,7 +136,7 @@ describe('PublicShareableDocumentList', () => {
         documents={documents}
         serviceInstance={serviceInstance}
         baseUrl={BaseUrl}
-        displayMode={ServiceListDisplayModeEnum.List}
+        displayMode={ServiceListDisplayMode.List}
       />
     );
     const firstRow = screen.getByText(FirstDocumentName).closest('tr');

--- a/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.test.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.test.tsx
@@ -1,3 +1,4 @@
+import { ServiceListDisplayModeEnum } from '@/components/service/components/header/ServiceListHeader';
 import testRender from '@/utils/test/test-render';
 import { publicDocumentListItemFragment$data } from '@generated/publicDocumentListItemFragment.graphql';
 import { seoServiceInstanceFragment$data } from '@generated/seoServiceInstanceFragment.graphql';
@@ -35,6 +36,7 @@ describe('PublicShareableDocumentList', () => {
         documents={documents}
         serviceInstance={serviceInstance}
         baseUrl="https://xtm.local"
+        displayMode={ServiceListDisplayModeEnum.Tab}
       />
     );
 

--- a/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.test.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.test.tsx
@@ -2,47 +2,77 @@ import { ServiceListDisplayModeEnum } from '@/components/service/components/head
 import testRender from '@/utils/test/test-render';
 import { publicDocumentListItemFragment$data } from '@generated/publicDocumentListItemFragment.graphql';
 import { seoServiceInstanceFragment$data } from '@generated/seoServiceInstanceFragment.graphql';
-import { screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { screen, within } from '@testing-library/react';
+import { useRouter } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PublicShareableDocumentList } from './PublicShareableDocumentList';
 
+const ServiceId = 'service-1';
+const ServiceSlug = 'my-service';
+const BaseUrl = 'https://xtm.local';
+const FirstDocumentId = 'doc-1';
+const FirstDocumentSlug = 'connector-doc';
+const FirstDocumentName = 'Connector document';
+const FirstDocumentDescription = 'Connector description';
+const SecondDocumentId = 'doc-2';
+const SecondDocumentSlug = 'dashboard-doc';
+const SecondDocumentName = 'Dashboard document';
+const SecondDocumentDescription = 'Dashboard description';
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+}));
+
 describe('PublicShareableDocumentList', () => {
+  beforeEach(() => {
+    vi.mocked(useRouter).mockReturnValue({
+      push: mocks.push,
+      replace: vi.fn(),
+      prefetch: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+    });
+  });
+
   const serviceInstance = {
-    id: 'service-1',
-    slug: 'my-service',
+    id: ServiceId,
+    slug: ServiceSlug,
   } as seoServiceInstanceFragment$data;
 
   const documents = [
     {
-      id: 'doc-1',
-      slug: 'connector-doc',
-      name: 'Connector document',
+      id: FirstDocumentId,
+      slug: FirstDocumentSlug,
+      name: FirstDocumentName,
       type: 'opencti_custom_dashboard',
-      short_description: 'Connector description',
+      short_description: FirstDocumentDescription,
       use_cases: [],
     },
     {
-      id: 'doc-2',
-      slug: 'dashboard-doc',
-      name: 'Dashboard document',
+      id: SecondDocumentId,
+      slug: SecondDocumentSlug,
+      name: SecondDocumentName,
       type: 'opencti_custom_dashboard',
-      short_description: 'Dashboard description',
+      short_description: SecondDocumentDescription,
       use_cases: [],
     },
   ] as publicDocumentListItemFragment$data[];
 
   it('renders one public card per document with expected public URLs in tab mode', () => {
+    // Given / When
     testRender(
       <PublicShareableDocumentList
         documents={documents}
         serviceInstance={serviceInstance}
-        baseUrl="https://xtm.local"
+        baseUrl={BaseUrl}
         displayMode={ServiceListDisplayModeEnum.Tab}
       />
     );
 
-    expect(screen.getByText('Connector document')).toBeInTheDocument();
-    expect(screen.getByText('Dashboard document')).toBeInTheDocument();
+    // Then
+    expect(screen.getByText(FirstDocumentName)).toBeInTheDocument();
+    expect(screen.getByText(SecondDocumentName)).toBeInTheDocument();
 
     const detailLinks = screen
       .getAllByRole('link')
@@ -53,31 +83,70 @@ describe('PublicShareableDocumentList', () => {
     expect(detailLinks).toHaveLength(2);
     expect(detailLinks[0]).toHaveAttribute(
       'href',
-      '/en/cybersecurity-solutions/my-service/connector-doc'
+      `/en/cybersecurity-solutions/${ServiceSlug}/${FirstDocumentSlug}`
     );
     expect(detailLinks[1]).toHaveAttribute(
       'href',
-      '/en/cybersecurity-solutions/my-service/dashboard-doc'
+      `/en/cybersecurity-solutions/${ServiceSlug}/${SecondDocumentSlug}`
     );
   });
 
   it('renders list mode without public detail card links', () => {
+    // Given / When
     testRender(
       <PublicShareableDocumentList
         documents={documents}
         serviceInstance={serviceInstance}
-        baseUrl="https://xtm.local"
+        baseUrl={BaseUrl}
         displayMode={ServiceListDisplayModeEnum.List}
       />
     );
 
-    expect(screen.getByText('Connector document')).toBeInTheDocument();
-    expect(screen.getByText('Dashboard document')).toBeInTheDocument();
-    expect(
-      screen.queryByRole('link', { name: 'Connector document' })
-    ).toBeNull();
-    expect(
-      screen.queryByRole('link', { name: 'Dashboard document' })
-    ).toBeNull();
+    // Then
+    expect(screen.getByText(FirstDocumentName)).toBeInTheDocument();
+    expect(screen.getByText(SecondDocumentName)).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: FirstDocumentName })).toBeNull();
+    expect(screen.queryByRole('link', { name: SecondDocumentName })).toBeNull();
+  });
+
+  it('should navigate to public detail page when clicking a row in list mode', async () => {
+    // Given
+    const { user } = testRender(
+      <PublicShareableDocumentList
+        documents={documents}
+        serviceInstance={serviceInstance}
+        baseUrl={BaseUrl}
+        displayMode={ServiceListDisplayModeEnum.List}
+      />
+    );
+
+    // When
+    await user.click(screen.getByText(FirstDocumentName).closest('tr')!);
+
+    // Then
+    expect(mocks.push).toHaveBeenCalledWith(
+      `/en/cybersecurity-solutions/${ServiceSlug}/${FirstDocumentSlug}`
+    );
+  });
+
+  it('should not navigate when clicking share action in list mode', async () => {
+    // Given
+    const { user } = testRender(
+      <PublicShareableDocumentList
+        documents={documents}
+        serviceInstance={serviceInstance}
+        baseUrl={BaseUrl}
+        displayMode={ServiceListDisplayModeEnum.List}
+      />
+    );
+    const firstRow = screen.getByText(FirstDocumentName).closest('tr');
+    const shareIcon = within(firstRow!).getByRole('img');
+    const shareActionButton = shareIcon.closest('button');
+
+    // When
+    await user.click(shareActionButton!);
+
+    // Then
+    expect(mocks.push).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.tsx
@@ -16,6 +16,7 @@ import { publicDocumentListItemFragment$data } from '@generated/publicDocumentLi
 import { seoServiceInstanceFragment$data } from '@generated/seoServiceInstanceFragment.graphql';
 import { ColumnDef } from '@tanstack/react-table';
 import { useLocale, useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
 import { useMemo } from 'react';
 
 interface PublicShareableDocumentListProps {
@@ -33,6 +34,7 @@ export const PublicShareableDocumentList = ({
 }: PublicShareableDocumentListProps) => {
   const locale = useLocale();
   const t = useTranslations();
+  const router = useRouter();
 
   const columns: ColumnDef<publicDocumentListItemFragment$data>[] = useMemo(
     () => [
@@ -71,10 +73,12 @@ export const PublicShareableDocumentList = ({
         id: 'action',
         header: t('Service.List.Tab.Actions'),
         cell: ({ row }) => (
-          <ShareLinkButton
-            documentId={row.original.id}
-            url={`${baseUrl}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${row.original.slug}`}
-          />
+          <div onClick={(event) => event.stopPropagation()}>
+            <ShareLinkButton
+              documentId={row.original.id}
+              url={`${baseUrl}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${row.original.slug}`}
+            />
+          </div>
         ),
       },
     ],
@@ -113,6 +117,11 @@ export const PublicShareableDocumentList = ({
         <DataTable
           columns={tableColumns}
           data={documents}
+          onClickRow={(row) =>
+            router.push(
+              `/${locale}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${row.original.slug}`
+            )
+          }
         />
       )}
     </>

--- a/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.tsx
@@ -1,37 +1,120 @@
+import {
+  DocumentNameCell,
+  DocumentShortDescriptionCell,
+} from '@/components/service/components/DocumentListCells';
+import { buildMetadataColumns } from '@/components/service/components/DocumentListColumns';
+import {
+  ServiceListDisplayMode,
+  ServiceListDisplayModeEnum,
+} from '@/components/service/components/header/ServiceListHeader';
+import BadgeOverflowCounter from '@/components/ui/BadgeOverflowCounter';
+import { ShareLinkButton } from '@/components/ui/share-link/ShareLinkButton';
 import ShareableResourceCard from '@/components/ui/shareable-resource/ShareableResourceCard';
 import { PUBLIC_CYBERSECURITY_SOLUTIONS_PATH } from '@/utils/path/constant';
+import { DataTable } from '@filigran/ui';
 import { publicDocumentListItemFragment$data } from '@generated/publicDocumentListItemFragment.graphql';
 import { seoServiceInstanceFragment$data } from '@generated/seoServiceInstanceFragment.graphql';
-import { useLocale } from 'next-intl';
+import { ColumnDef } from '@tanstack/react-table';
+import { useLocale, useTranslations } from 'next-intl';
+import { useMemo } from 'react';
 
 interface PublicShareableDocumentListProps {
   documents: publicDocumentListItemFragment$data[];
   serviceInstance: seoServiceInstanceFragment$data;
   baseUrl: string;
+  displayMode: ServiceListDisplayMode;
 }
 
 export const PublicShareableDocumentList = ({
   documents,
   serviceInstance,
   baseUrl,
+  displayMode,
 }: PublicShareableDocumentListProps) => {
   const locale = useLocale();
+  const t = useTranslations();
+
+  const columns: ColumnDef<publicDocumentListItemFragment$data>[] = useMemo(
+    () => [
+      {
+        accessorKey: 'name',
+        id: 'name',
+        header: t('Service.List.Tab.Name'),
+        cell: ({ row }) => <DocumentNameCell document={row.original} />,
+      },
+      {
+        accessorKey: 'short_description',
+        id: 'short_description',
+        header: t('Service.List.Tab.Description'),
+        cell: ({ row }) => (
+          <DocumentShortDescriptionCell document={row.original} />
+        ),
+      },
+      {
+        accessorKey: 'use_cases',
+        id: 'use_cases',
+        header: t('Service.List.Tab.UseCases'),
+        cell: ({ row }) => {
+          const document = row.original;
+
+          return (
+            <BadgeOverflowCounter
+              formatLabel={false}
+              badges={document.use_cases ?? []}
+              className="z-2 shrink-0"
+            />
+          );
+        },
+      },
+      {
+        accessorKey: 'action',
+        id: 'action',
+        header: t('Service.List.Tab.Actions'),
+        cell: ({ row }) => (
+          <ShareLinkButton
+            documentId={row.original.id}
+            url={`${baseUrl}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${row.original.slug}`}
+          />
+        ),
+      },
+    ],
+    [baseUrl, serviceInstance.slug, t]
+  );
+
+  const tableColumns = useMemo(
+    () =>
+      buildMetadataColumns({
+        columns,
+        documents,
+        t,
+      }),
+    [columns, documents, t]
+  );
 
   return (
-    <ul
-      className={
-        'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-l'
-      }>
-      {documents.map((document) => (
-        <ShareableResourceCard
-          publicPath
-          key={document.id}
-          document={document}
-          serviceInstance={serviceInstance}
-          detailUrl={`/${locale}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${document.slug}`}
-          shareLinkUrl={`${baseUrl}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${document.slug}`}
+    <>
+      {displayMode === ServiceListDisplayModeEnum.Tab ? (
+        <ul
+          className={
+            'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-l'
+          }>
+          {documents.map((document) => (
+            <ShareableResourceCard
+              publicPath
+              key={document.id}
+              document={document}
+              serviceInstance={serviceInstance}
+              detailUrl={`/${locale}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${document.slug}`}
+              shareLinkUrl={`${baseUrl}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${document.slug}`}
+            />
+          ))}
+        </ul>
+      ) : (
+        <DataTable
+          columns={tableColumns}
+          data={documents}
         />
-      ))}
-    </ul>
+      )}
+    </>
   );
 };

--- a/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.tsx
@@ -117,6 +117,7 @@ export const PublicShareableDocumentList = ({
         <DataTable
           columns={tableColumns}
           data={documents}
+          toolbar={<></>}
           onClickRow={(row) =>
             router.push(
               `/${locale}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${row.original.slug}`

--- a/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/PublicShareableDocumentList.tsx
@@ -3,13 +3,11 @@ import {
   DocumentShortDescriptionCell,
 } from '@/components/service/components/DocumentListCells';
 import { buildMetadataColumns } from '@/components/service/components/DocumentListColumns';
-import {
-  ServiceListDisplayMode,
-  ServiceListDisplayModeEnum,
-} from '@/components/service/components/header/ServiceListHeader';
+import { ServiceListDisplayMode } from '@/components/service/components/header/ServiceListHeader';
 import BadgeOverflowCounter from '@/components/ui/BadgeOverflowCounter';
 import { ShareLinkButton } from '@/components/ui/share-link/ShareLinkButton';
 import ShareableResourceCard from '@/components/ui/shareable-resource/ShareableResourceCard';
+import useScrollPosition from '@/hooks/use-scroll-position';
 import { PUBLIC_CYBERSECURITY_SOLUTIONS_PATH } from '@/utils/path/constant';
 import { DataTable } from '@filigran/ui';
 import { publicDocumentListItemFragment$data } from '@generated/publicDocumentListItemFragment.graphql';
@@ -33,6 +31,7 @@ export const PublicShareableDocumentList = ({
   displayMode,
 }: PublicShareableDocumentListProps) => {
   const locale = useLocale();
+  const { save } = useScrollPosition();
   const t = useTranslations();
   const router = useRouter();
 
@@ -71,6 +70,8 @@ export const PublicShareableDocumentList = ({
       {
         accessorKey: 'action',
         id: 'action',
+        enableHiding: false,
+        enableSorting: false,
         header: t('Service.List.Tab.Actions'),
         cell: ({ row }) => (
           <div onClick={(event) => event.stopPropagation()}>
@@ -97,7 +98,7 @@ export const PublicShareableDocumentList = ({
 
   return (
     <>
-      {displayMode === ServiceListDisplayModeEnum.Tab ? (
+      {displayMode === ServiceListDisplayMode.Tab ? (
         <ul
           className={
             'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-l'
@@ -118,11 +119,12 @@ export const PublicShareableDocumentList = ({
           columns={tableColumns}
           data={documents}
           toolbar={<></>}
-          onClickRow={(row) =>
+          onClickRow={(row) => {
+            save();
             router.push(
               `/${locale}/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${serviceInstance.slug}/${row.original.slug}`
-            )
-          }
+            );
+          }}
         />
       )}
     </>

--- a/apps/frontend/src/components/ui/shareable-resource/PublicShareableResourceList.test.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/PublicShareableResourceList.test.tsx
@@ -1,3 +1,4 @@
+import { ServiceListDisplayModeEnum } from '@/components/service/components/header/ServiceListHeader';
 import testRender from '@/utils/test/test-render';
 import { publicDocumentListItemFragment$data } from '@generated/publicDocumentListItemFragment.graphql';
 import { seoServiceInstanceFragment$data } from '@generated/seoServiceInstanceFragment.graphql';
@@ -23,6 +24,7 @@ describe('PublicShareableResourceList', () => {
         documents={[]}
         serviceInstance={serviceInstance as seoServiceInstanceFragment$data}
         baseUrl="https://xtm.local"
+        displayMode={ServiceListDisplayModeEnum.Tab}
       />
     );
 
@@ -52,6 +54,7 @@ describe('PublicShareableResourceList', () => {
         documents={documents as publicDocumentListItemFragment$data[]}
         serviceInstance={serviceInstance as seoServiceInstanceFragment$data}
         baseUrl="https://xtm.local"
+        displayMode={ServiceListDisplayModeEnum.Tab}
       />
     );
 

--- a/apps/frontend/src/components/ui/shareable-resource/PublicShareableResourceList.test.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/PublicShareableResourceList.test.tsx
@@ -1,4 +1,4 @@
-import { ServiceListDisplayModeEnum } from '@/components/service/components/header/ServiceListHeader';
+import { ServiceListDisplayMode } from '@/components/service/components/header/ServiceListHeader';
 import testRender from '@/utils/test/test-render';
 import { publicDocumentListItemFragment$data } from '@generated/publicDocumentListItemFragment.graphql';
 import { seoServiceInstanceFragment$data } from '@generated/seoServiceInstanceFragment.graphql';
@@ -24,7 +24,7 @@ describe('PublicShareableResourceList', () => {
         documents={[]}
         serviceInstance={serviceInstance as seoServiceInstanceFragment$data}
         baseUrl="https://xtm.local"
-        displayMode={ServiceListDisplayModeEnum.Tab}
+        displayMode={ServiceListDisplayMode.Tab}
       />
     );
 
@@ -54,7 +54,7 @@ describe('PublicShareableResourceList', () => {
         documents={documents as publicDocumentListItemFragment$data[]}
         serviceInstance={serviceInstance as seoServiceInstanceFragment$data}
         baseUrl="https://xtm.local"
-        displayMode={ServiceListDisplayModeEnum.Tab}
+        displayMode={ServiceListDisplayMode.Tab}
       />
     );
 

--- a/apps/frontend/src/components/ui/shareable-resource/PublicShareableResourceList.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/PublicShareableResourceList.tsx
@@ -1,3 +1,4 @@
+import { ServiceListDisplayMode } from '@/components/service/components/header/ServiceListHeader';
 import IntegrationAccordion from '@/components/ui/shareable-resource/IntegrationAccordion';
 import { PublicShareableDocumentList } from '@/components/ui/shareable-resource/PublicShareableDocumentList';
 import { isIntegrationItem } from '@/utils/shareable-resources/shareable-resources.types';
@@ -11,12 +12,14 @@ interface PublicShareableResourceListProps {
   documents: publicDocumentListItemFragment$data[];
   serviceInstance: seoServiceInstanceFragment$data;
   baseUrl: string;
+  displayMode: ServiceListDisplayMode;
 }
 
 export const PublicShareableResourceList = ({
   documents,
   serviceInstance,
   baseUrl,
+  displayMode,
 }: PublicShareableResourceListProps) => {
   const t = useTranslations();
 
@@ -58,6 +61,7 @@ export const PublicShareableResourceList = ({
                 count={documents.length}>
                 <PublicShareableDocumentList
                   documents={documents}
+                  displayMode={displayMode}
                   serviceInstance={serviceInstance}
                   baseUrl={baseUrl}
                 />
@@ -67,6 +71,7 @@ export const PublicShareableResourceList = ({
                 documents={documents}
                 serviceInstance={serviceInstance}
                 baseUrl={baseUrl}
+                displayMode={displayMode}
               />
             )}
           </Fragment>

--- a/apps/frontend/src/hooks/use-service-list-local-storage.test.tsx
+++ b/apps/frontend/src/hooks/use-service-list-local-storage.test.tsx
@@ -1,0 +1,134 @@
+import {
+  ServiceListDisplayModeEnum,
+  ServiceListFilterKey,
+} from '@/components/service/components/header/ServiceListHeader';
+import {
+  ServiceListLocalStorageKey,
+  useServiceListLocalStorage,
+} from '@/hooks/use-service-list-local-storage';
+import { DocumentOrdering, OrderingMode } from '@graphql/generated';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testState = vi.hoisted(() => ({
+  usePublicPath: vi.fn(),
+  useLocalStorage: vi.fn(),
+  removeFns: [] as Array<() => void>,
+}));
+
+vi.mock('@/hooks/use-public-path', () => ({
+  default: testState.usePublicPath,
+}));
+
+vi.mock('usehooks-ts', () => ({
+  useLocalStorage: testState.useLocalStorage,
+}));
+
+describe('useServiceListLocalStorage', () => {
+  beforeEach(() => {
+    testState.removeFns = [];
+    testState.usePublicPath.mockReturnValue(false);
+    testState.useLocalStorage.mockImplementation(
+      (_key: string, defaultValue: unknown) => {
+        const remove = vi.fn();
+        testState.removeFns.push(remove);
+        return [defaultValue, vi.fn(), remove];
+      }
+    );
+  });
+
+  it.each`
+    isPublicPath | expectedPrefix
+    ${true}      | ${'Public'}
+    ${false}     | ${'Private'}
+  `(
+    'uses "$expectedPrefix" local storage prefix when public path is $isPublicPath',
+    ({ isPublicPath, expectedPrefix }) => {
+      testState.usePublicPath.mockReturnValue(isPublicPath);
+
+      renderHook(() =>
+        useServiceListLocalStorage(
+          ServiceListLocalStorageKey.OpenCTICustomViews
+        )
+      );
+
+      expect(testState.useLocalStorage).toHaveBeenCalledWith(
+        `search${expectedPrefix}OpenCTICustomViewsList`,
+        ''
+      );
+      expect(testState.useLocalStorage).toHaveBeenCalledWith(
+        `displayMode${expectedPrefix}OpenCTICustomViewsList`,
+        ServiceListDisplayModeEnum.List
+      );
+    }
+  );
+
+  it.each`
+    serviceKey                                            | expectedDefaultOrderBy
+    ${ServiceListLocalStorageKey.OpenCTIIntegrationFeeds} | ${DocumentOrdering.Name}
+    ${ServiceListLocalStorageKey.OpenCTICustomDashboards} | ${DocumentOrdering.CreatedAt}
+  `(
+    'uses $expectedDefaultOrderBy as default orderBy for $serviceKey',
+    ({ serviceKey, expectedDefaultOrderBy }) => {
+      renderHook(() => useServiceListLocalStorage(serviceKey));
+
+      expect(testState.useLocalStorage).toHaveBeenCalledWith(
+        expect.stringContaining('orderByPrivate'),
+        expectedDefaultOrderBy
+      );
+    }
+  );
+
+  it('exposes expected default values', () => {
+    const { result } = renderHook(() =>
+      useServiceListLocalStorage(ServiceListLocalStorageKey.OpenAEVScenarios)
+    );
+
+    expect(result.current.search).toBe('');
+    expect(result.current.pageSize).toBe(50);
+    expect(result.current.count).toBe(50);
+    expect(result.current.orderMode).toBe(OrderingMode.Asc);
+    expect(result.current.displayMode).toBe(ServiceListDisplayModeEnum.List);
+    expect(result.current.labels).toEqual({});
+    expect(result.current.selectedFilters).toEqual([]);
+  });
+
+  it('resetAll calls every local storage remover', () => {
+    const { result } = renderHook(() =>
+      useServiceListLocalStorage(ServiceListLocalStorageKey.OpenCTIPlaybooks)
+    );
+
+    result.current.resetAll();
+
+    expect(testState.removeFns).toHaveLength(15);
+    for (const remove of testState.removeFns) {
+      expect(remove).toHaveBeenCalledOnce();
+    }
+  });
+
+  it('keeps selected filters values typed from valid enum entries', () => {
+    testState.useLocalStorage.mockImplementation(
+      (key: string, defaultValue: unknown) => {
+        const remove = vi.fn();
+        testState.removeFns.push(remove);
+        if (key.includes('selectedFilters')) {
+          return [
+            [ServiceListFilterKey.Label, ServiceListFilterKey.Verified],
+            vi.fn(),
+            remove,
+          ];
+        }
+        return [defaultValue, vi.fn(), remove];
+      }
+    );
+
+    const { result } = renderHook(() =>
+      useServiceListLocalStorage(ServiceListLocalStorageKey.OpenCTIPlaybooks)
+    );
+
+    expect(result.current.selectedFilters).toEqual([
+      ServiceListFilterKey.Label,
+      ServiceListFilterKey.Verified,
+    ]);
+  });
+});

--- a/apps/frontend/src/hooks/use-service-list-local-storage.test.tsx
+++ b/apps/frontend/src/hooks/use-service-list-local-storage.test.tsx
@@ -1,5 +1,5 @@
 import {
-  ServiceListDisplayModeEnum,
+  ServiceListDisplayMode,
   ServiceListFilterKey,
 } from '@/components/service/components/header/ServiceListHeader';
 import {
@@ -58,7 +58,7 @@ describe('useServiceListLocalStorage', () => {
       );
       expect(testState.useLocalStorage).toHaveBeenCalledWith(
         `displayMode${expectedPrefix}OpenCTICustomViewsList`,
-        ServiceListDisplayModeEnum.Tab
+        ServiceListDisplayMode.Tab
       );
     }
   );
@@ -88,7 +88,7 @@ describe('useServiceListLocalStorage', () => {
     expect(result.current.pageSize).toBe(50);
     expect(result.current.count).toBe(50);
     expect(result.current.orderMode).toBe(OrderingMode.Asc);
-    expect(result.current.displayMode).toBe(ServiceListDisplayModeEnum.Tab);
+    expect(result.current.displayMode).toBe(ServiceListDisplayMode.Tab);
     expect(result.current.labels).toEqual({});
     expect(result.current.selectedFilters).toEqual([]);
   });

--- a/apps/frontend/src/hooks/use-service-list-local-storage.test.tsx
+++ b/apps/frontend/src/hooks/use-service-list-local-storage.test.tsx
@@ -58,7 +58,7 @@ describe('useServiceListLocalStorage', () => {
       );
       expect(testState.useLocalStorage).toHaveBeenCalledWith(
         `displayMode${expectedPrefix}OpenCTICustomViewsList`,
-        ServiceListDisplayModeEnum.List
+        ServiceListDisplayModeEnum.Tab
       );
     }
   );
@@ -88,7 +88,7 @@ describe('useServiceListLocalStorage', () => {
     expect(result.current.pageSize).toBe(50);
     expect(result.current.count).toBe(50);
     expect(result.current.orderMode).toBe(OrderingMode.Asc);
-    expect(result.current.displayMode).toBe(ServiceListDisplayModeEnum.List);
+    expect(result.current.displayMode).toBe(ServiceListDisplayModeEnum.Tab);
     expect(result.current.labels).toEqual({});
     expect(result.current.selectedFilters).toEqual([]);
   });

--- a/apps/frontend/src/hooks/use-service-list-local-storage.ts
+++ b/apps/frontend/src/hooks/use-service-list-local-storage.ts
@@ -1,6 +1,5 @@
 import {
   ServiceListDisplayMode,
-  ServiceListDisplayModeEnum,
   ServiceListFilterKey,
 } from '@/components/service/components/header/ServiceListHeader';
 import {
@@ -172,7 +171,7 @@ export const useServiceListLocalStorage = (
   const [displayMode, setDisplayMode, removeDisplayMode] =
     useLocalStorage<ServiceListDisplayMode>(
       `displayMode${pagePrefix}${serviceName}List`,
-      ServiceListDisplayModeEnum.Tab
+      ServiceListDisplayMode.Tab
     );
 
   const resetAll = useCallback(() => {

--- a/apps/frontend/src/hooks/use-service-list-local-storage.ts
+++ b/apps/frontend/src/hooks/use-service-list-local-storage.ts
@@ -172,7 +172,7 @@ export const useServiceListLocalStorage = (
   const [displayMode, setDisplayMode, removeDisplayMode] =
     useLocalStorage<ServiceListDisplayMode>(
       `displayMode${pagePrefix}${serviceName}List`,
-      ServiceListDisplayModeEnum.List
+      ServiceListDisplayModeEnum.Tab
     );
 
   const resetAll = useCallback(() => {

--- a/apps/frontend/src/hooks/use-service-list-local-storage.ts
+++ b/apps/frontend/src/hooks/use-service-list-local-storage.ts
@@ -1,4 +1,8 @@
-import { ServiceListFilterKey } from '@/components/service/components/header/ServiceListHeader';
+import {
+  ServiceListDisplayMode,
+  ServiceListDisplayModeEnum,
+  ServiceListFilterKey,
+} from '@/components/service/components/header/ServiceListHeader';
 import {
   isLogicalMultiSelectSelection,
   LogicalMultiSelectSelection,
@@ -165,6 +169,11 @@ export const useServiceListLocalStorage = (
       `orderMode${pagePrefix}${serviceName}List`,
       OrderingMode.Asc
     );
+  const [displayMode, setDisplayMode, removeDisplayMode] =
+    useLocalStorage<ServiceListDisplayMode>(
+      `displayMode${pagePrefix}${serviceName}List`,
+      ServiceListDisplayModeEnum.List
+    );
 
   const resetAll = useCallback(() => {
     removeCount();
@@ -181,6 +190,7 @@ export const useServiceListLocalStorage = (
     removeVerified();
     removeOrderBy();
     removeOrderMode();
+    removeDisplayMode();
   }, [
     removeCount,
     removePageSize,
@@ -196,6 +206,7 @@ export const useServiceListLocalStorage = (
     removeVerified,
     removeOrderBy,
     removeOrderMode,
+    removeDisplayMode,
   ]);
 
   return {
@@ -238,5 +249,7 @@ export const useServiceListLocalStorage = (
     setOrderBy,
     orderMode,
     setOrderMode,
+    displayMode,
+    setDisplayMode,
   };
 };


### PR DESCRIPTION
# Context
> Add the possibility for the user to have view list or tab 

## How to test
- Stay on public pages. 
- Verify each library with view list and view tab. The share should work. 
- Login as admin. 
- Verify each library with view list and view tab. The share, update and delete should work. 
- Login as simple user. 
- on libraries, you should see in the action columns only the share button. 
- When you click on a row, you should be redirected to the detailed page. 

Uploading Enregistrement de l’écran 2026-08-21 à 15.12.31.mov…


## Related issues

- Related to #3134

# Checklist

## Quality

- [X] I consider this work complete and ready for review
- [X] I tested all features and edge cases
- [X] I refactored code where necessary to improve quality
- [X] I made sure my code meets development guidelines
- [X] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [X] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [X] Unit tests
- [ ] Integration tests
- [X] E2E tests
- [X] Local manual tests
