### PR TITLE
ci(merge-queue): add config for merge queue (#3163)

### DIFF
--- a/.github/workflows/dockerbuild-ci.yml
+++ b/.github/workflows/dockerbuild-ci.yml
@@ -2,6 +2,9 @@ name: Run XTM Hub CI/CD
 
 on:
   workflow_dispatch:
+  merge_group:
+    types:
+      - checks_requested
   push:
     branches:
       - "main"
@@ -522,6 +525,7 @@ jobs:
     if: |
       always() &&
       github.event_name != 'pull_request' &&
+      github.event_name != 'merge_group' &&
       (needs.run-lint.result == 'success') &&
       (needs.run-e2e-tests.result == 'success') &&
       (needs.run-front-unit-tests.result == 'skipped' || needs.run-front-unit-tests.result == 'success') &&
@@ -605,6 +609,7 @@ jobs:
     if: |
       always() &&
       github.event_name != 'pull_request' &&
+      github.event_name != 'merge_group' &&
       (needs.build-images-prod.result == 'success')
     steps:
       - name: Install AWX cli


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

Intro merge-queue to facilitate the PR to merge in main 
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue 

## How merge queue works
1. You click "Merge when ready" on your PR (once required reviews/checks pass, or even before — GitHub queues it automatically).
<img width="854" height="427" alt="image" src="https://github.com/user-attachments/assets/70dff574-23cc-41ab-b719-9313b05dfc22" />
2. GitHub adds your PR to a queue for the target branch (main). If other PRs are ahead of yours, they're processed first.
**Why this matters**: it guarantees main never breaks from "merge skew" (two PRs individually fine, but broken together), without forcing everyone to manually update/rebase before merging.

3. For each PR in the queue, GitHub creates a temporary "merge group" commit that combines your PR's changes with the latest target branch (and any PRs ahead of you already merged in the queue). Your actual PR branch is not modified — no rebase/update happens on your branch.
<img width="851" height="228" alt="image" src="https://github.com/user-attachments/assets/f83834f4-f952-45e6-8c59-1bdd06a47dc6" />

4. This temporary commit triggers our CI via the merge_group event (see dockerbuild-ci.yml) — running lint, unit tests, and e2e against the "as-if-merged" state.
5. If checks pass → GitHub merges your PR into main automatically.
6. If checks fail → your PR is removed from the queue, and you'll need to fix the issue and re-queue.

Status of the queue : https://github.com/XTM-Hub/xtm-hub/queue/main


