### PR TITLE
fix(public-slug): manage in front unknown slug (#3166)

### DIFF
--- a/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/[slug]/[docSlug]/docslug-page.utils.test.ts
+++ b/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/[slug]/[docSlug]/docslug-page.utils.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { isKnownDocumentSlug } from './docslug-page.utils';
+
+describe('isKnownDocumentSlug', () => {
+  it.each`
+    knownSlugs                         | slug         | expected | description
+    ${['foo', 'bar', 'baz']}           | ${'bar'}     | ${true}  | ${'slug present in the list'}
+    ${['foo', 'bar', 'baz']}           | ${'unknown'} | ${false} | ${'slug not present in the list'}
+    ${[]}                              | ${'foo'}     | ${false} | ${'empty known slugs list'}
+    ${['foo', null, undefined, 'bar']} | ${'bar'}     | ${true}  | ${'list containing null/undefined entries'}
+    ${['foo', null, undefined]}        | ${'unknown'} | ${false} | ${'unknown slug amongst null/undefined entries'}
+    ${['Foo']}                         | ${'foo'}     | ${false} | ${'lookup is case-sensitive'}
+  `(
+    'should return $expected for "$slug" ($description)',
+    ({ knownSlugs, slug, expected }) => {
+      expect(isKnownDocumentSlug(knownSlugs, slug)).toBe(expected);
+    }
+  );
+});

--- a/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/[slug]/[docSlug]/docslug-page.utils.ts
+++ b/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/[slug]/[docSlug]/docslug-page.utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Returns whether `slug` belongs to the given list of known document slugs.
+ * Used to short-circuit unknown/guessed `docSlug` navigations on the front
+ * end, before ever calling the backend for the document detail.
+ */
+export const isKnownDocumentSlug = (
+  knownSlugs: Array<string | null | undefined>,
+  slug: string
+): boolean => knownSlugs.includes(slug);

--- a/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/[slug]/[docSlug]/page.tsx
+++ b/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/[slug]/[docSlug]/page.tsx
@@ -27,7 +27,10 @@ import {
   getServiceInfo,
   isResourceDownloadable,
 } from '@/utils/shareable-resources/utils/shareable-resources.client.utils';
-import { fetchSingleDocument } from '@/utils/shareable-resources/utils/shareable-resources.server.utils';
+import {
+  fetchAllDocuments,
+  fetchSingleDocument,
+} from '@/utils/shareable-resources/utils/shareable-resources.server.utils';
 import { LogoFiligranIcon } from '@filigran/icon';
 import { MarkdownRenderer } from '@filigran/ui/clients';
 import { Button } from '@filigran/ui/servers';
@@ -41,6 +44,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { cache } from 'react';
+import { isKnownDocumentSlug } from './docslug-page.utils';
 const FALLBACK_DESCRIPTION_KEYS: Record<ServiceSlug, string> = {
   [ServiceSlug.OPEN_CTI_INTEGRATIONS]:
     'Metadata.DocumentFallbackDescriptionIntegration',
@@ -71,6 +75,22 @@ const getPageData = cache(async (serviceSlug: string, docSlug: string) => {
     .seoServiceInstance as unknown as seoServiceInstanceFragment$data;
 
   if (!serviceInstance) {
+    notFound();
+  }
+
+  // Reuses the same cached fetch as the parent list/SEO page, so this is a
+  // free lookup in the common case. It lets us reject unknown/guessed
+  // docSlug values without ever calling the backend for the document detail.
+  const knownDocuments = await fetchAllDocuments(
+    serviceInstance.slug as ServiceSlug
+  );
+
+  if (
+    !isKnownDocumentSlug(
+      knownDocuments.map((doc) => doc.slug),
+      docSlug
+    )
+  ) {
     notFound();
   }
 

--- a/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/[slug]/[docSlug]/page.tsx
+++ b/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/[slug]/[docSlug]/page.tsx
@@ -9,6 +9,7 @@ import { ShareLinkButton } from '@/components/ui/share-link/ShareLinkButton';
 import type { PublicLocale } from '@/i18n/config';
 import { RelayProvider } from '@/relay/relay-provider';
 import { serverFetchGraphQL } from '@/relay/server-portal-api-fetch';
+import { PUBLIC_PAGE_REVALIDATE_SECONDS } from '@/utils/constant';
 import { filterDocumentImages, findDocumentLogo } from '@/utils/documents';
 import { formatPersonNames } from '@/utils/format/name';
 import {
@@ -68,7 +69,7 @@ const getPageData = cache(async (serviceSlug: string, docSlug: string) => {
   const serviceResponse = await serverFetchGraphQL<seoServiceInstanceQuery>(
     SeoServiceInstanceQuery,
     { slug: serviceSlug },
-    { cache: undefined, next: { revalidate: 3600 } }
+    { cache: undefined, next: { revalidate: PUBLIC_PAGE_REVALIDATE_SECONDS } }
   );
 
   const serviceInstance = serviceResponse.data
@@ -94,7 +95,11 @@ const getPageData = cache(async (serviceSlug: string, docSlug: string) => {
     notFound();
   }
 
-  const document = await fetchSingleDocument(serviceInstance.id, docSlug);
+  const document = await fetchSingleDocument(
+    serviceInstance.id,
+    serviceInstance.slug as string,
+    docSlug
+  );
   if (!document) {
     notFound();
   }

--- a/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/[slug]/page.tsx
+++ b/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { BreadcrumbNav } from '@/components/ui/BreadcrumbNav';
 import type { PublicLocale } from '@/i18n/config';
 import { RelayProvider } from '@/relay/relay-provider';
 import { serverFetchGraphQL } from '@/relay/server-portal-api-fetch';
+import { PUBLIC_PAGE_REVALIDATE_SECONDS } from '@/utils/constant';
 import { formatPersonNames } from '@/utils/format/name';
 import {
   buildFiligranOrganizationJsonLd,
@@ -38,7 +39,7 @@ const getPageData = cache(async (slug: string, locale: PublicLocale) => {
   const serviceResponse = await serverFetchGraphQL<seoServiceInstanceQuery>(
     SeoServiceInstanceQuery,
     { slug },
-    { cache: undefined, next: { revalidate: 3600 } }
+    { cache: undefined, next: { revalidate: PUBLIC_PAGE_REVALIDATE_SECONDS } }
   );
 
   const serviceInstance = serviceResponse.data
@@ -55,7 +56,7 @@ const getPageData = cache(async (slug: string, locale: PublicLocale) => {
         service_instance_id: serviceInstance.id,
         language: locale,
       },
-      { cache: undefined, next: { revalidate: 3600 } }
+      { cache: undefined, next: { revalidate: PUBLIC_PAGE_REVALIDATE_SECONDS } }
     );
   const seoMetadata = seoMetadataResponse.data.seoServiceInstanceMetadata[0];
 

--- a/apps/frontend/src/components/service/document/use-document-context.ts
+++ b/apps/frontend/src/components/service/document/use-document-context.ts
@@ -22,6 +22,7 @@ import { OpenctiPlaybookForm } from '@/components/service/opencti-playbooks/[ser
 import { omit } from '@/lib/omit';
 import { pick } from '@/lib/pick';
 import { splitFileListToUploadableMap } from '@/relay/environment/fetch-form-data';
+import revalidateDocumentSlugsAction from '@/utils/actions/revalidate-document-slugs.actions';
 import {
   docIsExistingFile,
   isFile,
@@ -145,6 +146,9 @@ export function useDocumentContext({
           return;
         }
 
+        if (serviceInstance.slug) {
+          revalidateDocumentSlugsAction(serviceInstance.slug);
+        }
         onSuccess(input.name);
       },
       onError: (error) => {
@@ -169,6 +173,9 @@ export function useDocumentContext({
         forceDelete: true,
       },
       onCompleted() {
+        if (serviceInstance.slug) {
+          revalidateDocumentSlugsAction(serviceInstance.slug);
+        }
         onCompleted();
       },
     });
@@ -226,6 +233,9 @@ export function useDocumentContext({
         ...(isFile(logo[0]) ? { logo } : {}),
       }),
       onCompleted: () => {
+        if (serviceInstance.slug) {
+          revalidateDocumentSlugsAction(serviceInstance.slug);
+        }
         onSuccess(values.name);
       },
       onError: (error) => {

--- a/apps/frontend/src/components/service/document/use-document-context.ts
+++ b/apps/frontend/src/components/service/document/use-document-context.ts
@@ -174,7 +174,7 @@ export function useDocumentContext({
       },
       onCompleted() {
         if (serviceInstance.slug) {
-          revalidateDocumentSlugsAction(serviceInstance.slug);
+          revalidateDocumentSlugsAction(serviceInstance.slug, document.slug);
         }
         onCompleted();
       },
@@ -234,7 +234,7 @@ export function useDocumentContext({
       }),
       onCompleted: () => {
         if (serviceInstance.slug) {
-          revalidateDocumentSlugsAction(serviceInstance.slug);
+          revalidateDocumentSlugsAction(serviceInstance.slug, resource.slug);
         }
         onSuccess(values.name);
       },

--- a/apps/frontend/src/utils/actions/revalidate-document-slugs.actions.ts
+++ b/apps/frontend/src/utils/actions/revalidate-document-slugs.actions.ts
@@ -1,21 +1,25 @@
 'use server';
-import { publicDocumentsCacheTag } from '@/utils/shareable-resources/utils/shareable-resources.server.utils';
+import {
+  publicDocumentCacheTag,
+  publicDocumentsCacheTag,
+} from '@/utils/shareable-resources/utils/shareable-resources.server.utils';
 import { updateTag } from 'next/cache';
 
 /**
- * Invalidates the cached list of public documents for a service instance, so
- * the public `[slug]/[docSlug]` page and `app/sitemap.ts` (both reuse
- * `fetchAllDocuments`) pick up newly created/updated/deleted document slugs
- * immediately instead of serving a stale list.
+ * Invalidates the cached public document list (and sitemap) for a service
+ * instance after a create/update/delete. Pass `docSlug` on update/delete to
+ * also invalidate that document's own detail cache; omit it on creation.
  *
- * Uses `updateTag` (not `revalidateTag`) on purpose: this is called from a
- * Server Action right after a document mutation, and we need read-your-own-
- * writes semantics — the very next request must see fresh data, not a
- * stale-while-revalidate response, otherwise a user could be redirected to
- * the document they just created/updated and hit a false 404.
+ * Uses `updateTag` (not `revalidateTag`) for read-your-own-writes: the next
+ * request must see fresh data immediately, not a stale-while-revalidate
+ * response that could 404 a document the user just created/updated.
  */
 export default async function revalidateDocumentSlugsAction(
-  serviceInstanceSlug: string
+  serviceInstanceSlug: string,
+  docSlug?: string | null
 ) {
   updateTag(publicDocumentsCacheTag(serviceInstanceSlug));
+  if (docSlug) {
+    updateTag(publicDocumentCacheTag(serviceInstanceSlug, docSlug));
+  }
 }

--- a/apps/frontend/src/utils/actions/revalidate-document-slugs.actions.ts
+++ b/apps/frontend/src/utils/actions/revalidate-document-slugs.actions.ts
@@ -1,0 +1,21 @@
+'use server';
+import { publicDocumentsCacheTag } from '@/utils/shareable-resources/utils/shareable-resources.server.utils';
+import { updateTag } from 'next/cache';
+
+/**
+ * Invalidates the cached list of public documents for a service instance, so
+ * the public `[slug]/[docSlug]` page and `app/sitemap.ts` (both reuse
+ * `fetchAllDocuments`) pick up newly created/updated/deleted document slugs
+ * immediately instead of serving a stale list.
+ *
+ * Uses `updateTag` (not `revalidateTag`) on purpose: this is called from a
+ * Server Action right after a document mutation, and we need read-your-own-
+ * writes semantics — the very next request must see fresh data, not a
+ * stale-while-revalidate response, otherwise a user could be redirected to
+ * the document they just created/updated and hit a false 404.
+ */
+export default async function revalidateDocumentSlugsAction(
+  serviceInstanceSlug: string
+) {
+  updateTag(publicDocumentsCacheTag(serviceInstanceSlug));
+}

--- a/apps/frontend/src/utils/constant.ts
+++ b/apps/frontend/src/utils/constant.ts
@@ -2,3 +2,9 @@ export const DEBOUNCE_TIME = 300;
 export const ANIMATION_TIME = 300;
 export const PLATFORM_ORGANIZATION_UUID =
   'ba091095-418f-4b4f-b150-6c9295e232c4';
+
+/**
+ * Fallback revalidation window (seconds) shared by public SEO and document
+ * queries, so neither goes stale longer than the other.
+ */
+export const PUBLIC_PAGE_REVALIDATE_SECONDS = 60 * 60 * 6; // 6 hours

--- a/apps/frontend/src/utils/shareable-resources/utils/shareable-resources.server.utils.ts
+++ b/apps/frontend/src/utils/shareable-resources/utils/shareable-resources.server.utils.ts
@@ -6,6 +6,26 @@ import type { publicDocumentBySlugItemFragment$data } from '@generated/publicDoc
 import publicDocumentBySlugQueryGraphql from '@generated/publicDocumentBySlugQuery.graphql';
 import publicDocumentsByServiceSlugQueryGraphql from '@generated/publicDocumentsByServiceSlugQuery.graphql';
 
+/**
+ * Cache tag used to (in)validate the cached list of public documents for a
+ * given service instance. Call `updateTag(publicDocumentsCacheTag(slug))`
+ * (see `revalidate-document-slugs.actions.ts`) whenever a document is
+ * created, updated or deleted so both `fetchAllDocuments` and the
+ * `app/sitemap.ts` route (which reuses this same function) stay fresh.
+ */
+export const publicDocumentsCacheTag = (serviceInstanceSlug: string): string =>
+  `public-documents:${serviceInstanceSlug}`;
+
+/**
+ * Fallback time-based revalidation for public document data. Some documents
+ * (e.g. connectors) are created/updated by backend processes (manifest
+ * ingestion) that don't go through the front-end mutations wired to
+ * `revalidateDocumentSlugsAction`, so on-demand tag invalidation alone
+ * wouldn't pick up their changes. This periodic revalidation guarantees data
+ * is never stale for longer than this window, regardless of how it changed.
+ */
+const PUBLIC_DOCUMENTS_REVALIDATE_SECONDS = 60 * 60 * 6; // 6 hours
+
 export async function fetchAllDocuments(
   serviceInstanceSlug: ServiceSlug
 ): Promise<publicDocumentByServiceSlugItemFragment$data[]> {
@@ -15,7 +35,13 @@ export async function fetchAllDocuments(
   const response = await serverFetchGraphQL(
     publicDocumentsByServiceSlugQueryGraphql,
     { serviceInstanceSlug },
-    { cache: 'force-cache' }
+    {
+      cache: 'force-cache',
+      next: {
+        tags: [publicDocumentsCacheTag(serviceInstanceSlug)],
+        revalidate: PUBLIC_DOCUMENTS_REVALIDATE_SECONDS,
+      },
+    }
   );
 
   const safeData = response.data as Record<string, unknown>;
@@ -31,7 +57,10 @@ export async function fetchSingleDocument(
   const response = await serverFetchGraphQL(
     publicDocumentBySlugQueryGraphql,
     { slug, serviceInstanceId },
-    { cache: 'force-cache' }
+    {
+      cache: 'force-cache',
+      next: { revalidate: PUBLIC_DOCUMENTS_REVALIDATE_SECONDS },
+    }
   );
   const safeData = response.data as Record<string, unknown>;
   return safeData[

--- a/apps/frontend/src/utils/shareable-resources/utils/shareable-resources.server.utils.ts
+++ b/apps/frontend/src/utils/shareable-resources/utils/shareable-resources.server.utils.ts
@@ -1,5 +1,5 @@
 import { serverFetchGraphQL } from '@/relay/server-portal-api-fetch';
-
+import { PUBLIC_PAGE_REVALIDATE_SECONDS } from '@/utils/constant';
 import { ServiceSlug } from '@/utils/shareable-resources/shareable-resources.types';
 import type { publicDocumentByServiceSlugItemFragment$data } from '@generated/publicDocumentByServiceSlugItemFragment.graphql';
 import type { publicDocumentBySlugItemFragment$data } from '@generated/publicDocumentBySlugItemFragment.graphql';
@@ -7,25 +7,29 @@ import publicDocumentBySlugQueryGraphql from '@generated/publicDocumentBySlugQue
 import publicDocumentsByServiceSlugQueryGraphql from '@generated/publicDocumentsByServiceSlugQuery.graphql';
 
 /**
- * Cache tag used to (in)validate the cached list of public documents for a
- * given service instance. Call `updateTag(publicDocumentsCacheTag(slug))`
- * (see `revalidate-document-slugs.actions.ts`) whenever a document is
- * created, updated or deleted so both `fetchAllDocuments` and the
- * `app/sitemap.ts` route (which reuses this same function) stay fresh.
+ * Cache tag for the public document list of a service instance. Invalidated
+ * via `updateTag` in `revalidate-document-slugs.actions.ts` on document
+ * create/update/delete; also used by `app/sitemap.ts`.
  */
 export const publicDocumentsCacheTag = (serviceInstanceSlug: string): string =>
   `public-documents:${serviceInstanceSlug}`;
 
 /**
- * Fallback time-based revalidation for public document data. Some documents
- * (e.g. connectors) are created/updated by backend processes (manifest
- * ingestion) that don't go through the front-end mutations wired to
- * `revalidateDocumentSlugsAction`, so on-demand tag invalidation alone
- * wouldn't pick up their changes. This periodic revalidation guarantees data
- * is never stale for longer than this window, regardless of how it changed.
+ * Cache tag for a single public document. Scoped by `serviceInstanceSlug`
+ * because `docSlug` alone isn't unique (unique per `type` + `slug` +
+ * `version` in DB), matching how the backend looks it up.
  */
-const PUBLIC_DOCUMENTS_REVALIDATE_SECONDS = 60 * 60 * 6; // 6 hours
+export const publicDocumentCacheTag = (
+  serviceInstanceSlug: string,
+  docSlug: string
+): string => `public-document:${serviceInstanceSlug}:${docSlug}`;
 
+/**
+ * Fetches every public document of a service instance; also used to
+ * validate `docSlug` on the detail page before calling the backend for a
+ * single document. Tag-invalidated on demand, with a 6h fallback revalidate
+ * to catch backend-side changes (e.g. connector manifest ingestion).
+ */
 export async function fetchAllDocuments(
   serviceInstanceSlug: ServiceSlug
 ): Promise<publicDocumentByServiceSlugItemFragment$data[]> {
@@ -39,7 +43,7 @@ export async function fetchAllDocuments(
       cache: 'force-cache',
       next: {
         tags: [publicDocumentsCacheTag(serviceInstanceSlug)],
-        revalidate: PUBLIC_DOCUMENTS_REVALIDATE_SECONDS,
+        revalidate: PUBLIC_PAGE_REVALIDATE_SECONDS,
       },
     }
   );
@@ -50,8 +54,10 @@ export async function fetchAllDocuments(
   ] as publicDocumentByServiceSlugItemFragment$data[];
 }
 
+/** Fetches a single public document by slug; same caching as `fetchAllDocuments`. */
 export async function fetchSingleDocument(
   serviceInstanceId: string,
+  serviceInstanceSlug: string,
   slug: string
 ): Promise<publicDocumentBySlugItemFragment$data | null> {
   const response = await serverFetchGraphQL(
@@ -59,7 +65,10 @@ export async function fetchSingleDocument(
     { slug, serviceInstanceId },
     {
       cache: 'force-cache',
-      next: { revalidate: PUBLIC_DOCUMENTS_REVALIDATE_SECONDS },
+      next: {
+        tags: [publicDocumentCacheTag(serviceInstanceSlug, slug)],
+        revalidate: PUBLIC_PAGE_REVALIDATE_SECONDS,
+      },
     }
   );
   const safeData = response.data as Record<string, unknown>;


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

We're rewriting the slug strategy so the frontend builds a known-slug set from all documents fetched from the backend. Once built, any slug not present in that set is immediately routed to "not found" without querying the backend

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

- **Known slug loads normally:** Navigate to an existing document's slug URL directly (fresh tab, no prior nav) → confirm the page renders without errors.

- **Unknown slug → instant 404, no backend call:** Open browser DevTools → Network tab, navigate to a made-up/random slug → confirm you land on the "not found" page and **no GraphQL/API request** is fired (only static assets load).

- **Front-triggered edit updates instantly:** Edit a document via the front UI (e.g. Vault edit form) → confirm the page reflects changes immediately after save, without waiting for the 6h cycle.


## Related issues

- Related to #3166

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.