### PR TITLE
docs(testing): protect existing tests from AI rewrites (#3167)

### DIFF
--- a/.github/skills/testing-validation/SKILL.md
+++ b/.github/skills/testing-validation/SKILL.md
@@ -8,6 +8,16 @@ description: Shared XTM Hub expectations for adding tests and validating changes
 Shared testing and validation expectations for XTM Hub code changes. Layer- and domain-specific test rules (e.g. backend
 integration testing) build on top of these.
 
+## Protecting Existing Tests
+
+- Adding **new** tests (new `it`/`describe` blocks, new files) is always encouraged and never requires asking first.
+- Do **not** rewrite, restructure, delete, or change the scenario/assertions of an **existing** test unless either:
+    - it fails to compile/run purely because of a change you were asked to make (e.g. renamed import, changed function
+    signature), or
+    - its expectations must change to strictly match a business-logic change you were explicitly asked to implement.
+- If an existing test looks wrong, outdated, redundant, or in need of restructuring for reasons unrelated to the above,
+  stop and ask before touching it — do not silently rewrite it.
+
 ## Adding Tests
 
 - Add or update tests near the changed files (`*.test.ts` / `*.test.tsx`).

--- a/.github/skills/testing-validation/SKILL.md
+++ b/.github/skills/testing-validation/SKILL.md
@@ -12,8 +12,7 @@ integration testing) build on top of these.
 
 - Adding **new** tests (new `it`/`describe` blocks, new files) is always encouraged and never requires asking first.
 - Do **not** rewrite, restructure, delete, or change the scenario/assertions of an **existing** test unless either:
-    - it fails to compile/run purely because of a change you were asked to make (e.g. renamed import, changed function
-    signature), or
+    - it fails to compile/run purely because of a change you were asked to make (e.g. renamed import, changed function signature), or
     - its expectations must change to strictly match a business-logic change you were explicitly asked to implement.
 - If an existing test looks wrong, outdated, redundant, or in need of restructuring for reasons unrelated to the above,
   stop and ask before touching it — do not silently rewrite it.


### PR DESCRIPTION
## Summary

Adds a "Protecting Existing Tests" section to `.github/skills/testing-validation/SKILL.md` to prevent the AI from silently rewriting existing test scenarios/assertions during agentic coding sessions.

## Rule added

- Adding **new** tests is always encouraged and needs no prior confirmation.
- Existing tests must **not** be rewritten/restructured/deleted unless:
  - fixing a compile/run break caused by an explicitly requested change, or
  - updating expectations to strictly match an explicitly requested business-logic change.
- If a test looks wrong/outdated/needs restructuring for any other reason, the AI must stop and ask before touching it.

Closes #3167