### PR TITLE
feat(libraries): Remove count in accordion (#3174)

### DIFF
--- a/apps/e2e/tests/model/integration.pageModel.ts
+++ b/apps/e2e/tests/model/integration.pageModel.ts
@@ -62,7 +62,6 @@ export default class IntegrationPage {
     await selectSolutionCategories(this.page);
     await this.page.getByRole('radio', { name: 'Commercial' }).click();
     await this.page.getByRole('button', { name: 'Validate' }).click();
-    await this.page.getByText('TAXII Feeds').click();
   }
   async fillRssFeed({
     name,
@@ -93,7 +92,6 @@ export default class IntegrationPage {
     await selectSolutionCategories(this.page);
     await this.page.getByRole('radio', { name: 'Commercial' }).click();
     await this.page.getByRole('button', { name: 'Validate' }).click();
-    await this.page.getByText('RSS Feeds').click();
   }
 
   async fillStream({
@@ -127,7 +125,6 @@ export default class IntegrationPage {
     await selectSolutionCategories(this.page);
     await this.page.getByRole('radio', { name: 'Commercial' }).click();
     await this.page.getByRole('button', { name: 'Validate' }).click();
-    await this.page.getByText('OpenCTI Streams').click();
   }
   async fillCsvFeed({
     name,
@@ -158,7 +155,6 @@ export default class IntegrationPage {
     await selectSolutionCategories(this.page);
     await this.page.getByRole('radio', { name: 'Commercial' }).click();
     await this.page.getByRole('button', { name: 'Validate' }).click();
-    await this.page.getByText('CSV Feeds').click();
   }
 
   async fillThirdPartyIntegration({
@@ -204,7 +200,6 @@ export default class IntegrationPage {
     await selectSolutionCategories(this.page);
     await this.page.getByRole('radio', { name: 'Commercial' }).click();
     await this.page.getByRole('button', { name: 'Validate' }).click();
-    await this.page.getByText('Third Party integrations').click();
   }
 
   async navigateToIntegration(shortDescription: string) {

--- a/apps/e2e/tests/tests_files/capabilities.spec.ts
+++ b/apps/e2e/tests/tests_files/capabilities.spec.ts
@@ -107,7 +107,6 @@ test.describe('Capabilities', () => {
     await test.step('Simple user can delete integration', async () => {
       await loginPage.navigateToAndLogin(TEST_CAPABILITY.userThalesEmail);
       await integrationPage.navigateToIntegrationsService();
-      await page.getByText('CSV Feeds').click();
 
       const openMenuButton = page.getByRole('button', {
         name: 'Open menu',

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@filigran/icon": "0.24.3",
-    "@filigran/ui": "1.6.7",
+    "@filigran/ui": "1.6.8",
     "@hookform/resolvers": "5.9.1",
     "@svgr/webpack": "8.1.0",
     "@tailwindcss/postcss": "4.3.3",

--- a/apps/frontend/src/components/service/components/ServiceList.test.tsx
+++ b/apps/frontend/src/components/service/components/ServiceList.test.tsx
@@ -195,7 +195,7 @@ describe('ServiceList', () => {
     expect(screen.queryByText('Draft document')).toBeNull();
   });
 
-  it('groups known integration types in accordion and keeps unknown types as plain lists', async () => {
+  it('groups known integration types in accordion and keeps unknown types as plain lists', () => {
     const active = [
       {
         id: 'active-1',
@@ -216,7 +216,7 @@ describe('ServiceList', () => {
       },
     ] as Partial<documentItem_fragment$data>[];
 
-    const { user } = testRender(
+    testRender(
       <ServiceList
         active={active}
         draft={[]}
@@ -231,14 +231,6 @@ describe('ServiceList', () => {
       )
     ).toBeInTheDocument();
     expect(screen.getByText('Dashboard document')).toBeInTheDocument();
-
-    await user.click(
-      screen.getByRole('button', {
-        name: new RegExp(
-          `Service\\.OpenctiIntegrations\\.Type\\.${IntegrationType.Connector}`
-        ),
-      })
-    );
 
     expect(screen.getByText('Connector document')).toBeInTheDocument();
   });

--- a/apps/frontend/src/components/service/components/ServiceList.tsx
+++ b/apps/frontend/src/components/service/components/ServiceList.tsx
@@ -132,8 +132,7 @@ const ServiceList = ({
               integrationType as IntegrationType
             ) ? (
               <IntegrationAccordion
-                integrationType={integrationType}
-                count={documents.length}>
+                integrationType={integrationType}>
                 <DocumentList
                   documents={documents}
                   displayMode={selectedDisplayMode}

--- a/apps/frontend/src/components/service/components/ServiceList.tsx
+++ b/apps/frontend/src/components/service/components/ServiceList.tsx
@@ -131,8 +131,7 @@ const ServiceList = ({
             {Object.values(IntegrationType).includes(
               integrationType as IntegrationType
             ) ? (
-              <IntegrationAccordion
-                integrationType={integrationType}>
+              <IntegrationAccordion integrationType={integrationType}>
                 <DocumentList
                   documents={documents}
                   displayMode={selectedDisplayMode}

--- a/apps/frontend/src/components/ui/shareable-resource/IntegrationAccordion.test.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/IntegrationAccordion.test.tsx
@@ -5,19 +5,16 @@ import IntegrationAccordion from './IntegrationAccordion';
 
 describe('IntegrationAccordion', () => {
   const integrationType = 'connector';
-  const count = 2;
   const childrenText = 'accordion-child-content';
   const triggerLabelPattern = new RegExp(
     `Service\\.OpenctiIntegrations\\.Type\\.${integrationType}`
   );
 
-  it('should display the accordion label and count when rendered', () => {
+  it('should display the accordion label when rendered', () => {
     // Given
     // When
     testRender(
-      <IntegrationAccordion
-        integrationType={integrationType}
-        count={count}>
+      <IntegrationAccordion integrationType={integrationType}>
         <div>{childrenText}</div>
       </IntegrationAccordion>
     );
@@ -26,15 +23,12 @@ describe('IntegrationAccordion', () => {
     expect(
       screen.getByRole('button', { name: triggerLabelPattern })
     ).toBeInTheDocument();
-    expect(screen.getByText(String(count))).toBeInTheDocument();
   });
 
   it('should display the children when the accordion is opened', async () => {
     // Given
     const { user } = testRender(
-      <IntegrationAccordion
-        integrationType={integrationType}
-        count={count}>
+      <IntegrationAccordion integrationType={integrationType}>
         <div>{childrenText}</div>
       </IntegrationAccordion>
     );

--- a/apps/frontend/src/components/ui/shareable-resource/IntegrationAccordion.test.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/IntegrationAccordion.test.tsx
@@ -25,16 +25,13 @@ describe('IntegrationAccordion', () => {
     ).toBeInTheDocument();
   });
 
-  it('should display the children when the accordion is opened', async () => {
+  it('should display the children by default', () => {
     // Given
-    const { user } = testRender(
+    testRender(
       <IntegrationAccordion integrationType={integrationType}>
         <div>{childrenText}</div>
       </IntegrationAccordion>
     );
-
-    // When
-    await user.click(screen.getByRole('button', { name: triggerLabelPattern }));
 
     // Then
     expect(screen.getByText(childrenText)).toBeInTheDocument();

--- a/apps/frontend/src/components/ui/shareable-resource/IntegrationAccordion.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/IntegrationAccordion.tsx
@@ -20,8 +20,8 @@ const IntegrationAccordion = ({
 
   return (
     <Accordion
-      type="single"
-      collapsible>
+      type="multiple"
+      defaultValue={[integrationType]}>
       <AccordionItem value={integrationType}>
         <h2 className="m-0">
           <AccordionTrigger className="hover:cursor-pointer">

--- a/apps/frontend/src/components/ui/shareable-resource/IntegrationAccordion.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/IntegrationAccordion.tsx
@@ -1,4 +1,3 @@
-import { CountBadge } from '@/components/ui/CountBadge';
 import {
   Accordion,
   AccordionContent,
@@ -10,13 +9,11 @@ import React from 'react';
 
 interface IntegrationAccordionProps {
   integrationType: string;
-  count: number;
   children: React.ReactNode;
 }
 
 const IntegrationAccordion = ({
   integrationType,
-  count,
   children,
 }: IntegrationAccordionProps) => {
   const t = useTranslations();
@@ -30,11 +27,6 @@ const IntegrationAccordion = ({
           <AccordionTrigger className="hover:cursor-pointer">
             <div className="inline-flex items-center gap-s">
               {t(`Service.OpenctiIntegrations.Type.${integrationType}`)}
-              <CountBadge
-                count={count}
-                bgFadedClass={'bg-feedback-neutral-secondary-transparency'}
-                textClass={'text-feedback-neutral-primary'}
-              />
             </div>
           </AccordionTrigger>
         </h2>

--- a/apps/frontend/src/components/ui/shareable-resource/IntegrationAccordion.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/IntegrationAccordion.tsx
@@ -21,10 +21,11 @@ const IntegrationAccordion = ({
   return (
     <Accordion
       type="multiple"
+
       defaultValue={[integrationType]}>
       <AccordionItem value={integrationType}>
         <h2 className="m-0">
-          <AccordionTrigger className="hover:cursor-pointer">
+          <AccordionTrigger variant="colored">
             <div className="inline-flex items-center gap-s">
               {t(`Service.OpenctiIntegrations.Type.${integrationType}`)}
             </div>

--- a/apps/frontend/src/components/ui/shareable-resource/PublicShareableResourceList.test.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/PublicShareableResourceList.test.tsx
@@ -31,7 +31,7 @@ describe('PublicShareableResourceList', () => {
     expect(screen.getByText('Utils.DocumentNotFound')).toBeInTheDocument();
   });
 
-  it('groups integrations by integration_type and renders document names with correct links', async () => {
+  it('groups integrations by integration_type and renders document names with correct links', () => {
     const documents = [
       {
         id: 'doc-1',
@@ -49,7 +49,7 @@ describe('PublicShareableResourceList', () => {
       },
     ];
 
-    const { user } = testRender(
+    testRender(
       <PublicShareableResourceList
         documents={documents as publicDocumentListItemFragment$data[]}
         serviceInstance={serviceInstance as seoServiceInstanceFragment$data}
@@ -65,13 +65,6 @@ describe('PublicShareableResourceList', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('My Dashboard')).toBeInTheDocument();
 
-    await user.click(
-      screen.getByRole('button', {
-        name: new RegExp(
-          `Service\\.OpenctiIntegrations\\.Type\\.${IntegrationType.Connector}`
-        ),
-      })
-    );
     expect(screen.getByText('My Connector')).toBeInTheDocument();
 
     const links = screen.getAllByRole('link');

--- a/apps/frontend/src/components/ui/shareable-resource/PublicShareableResourceList.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/PublicShareableResourceList.tsx
@@ -57,8 +57,7 @@ export const PublicShareableResourceList = ({
             ) ? (
               <IntegrationAccordion
                 key={integrationType}
-                integrationType={integrationType}
-                count={documents.length}>
+                integrationType={integrationType}>
                 <PublicShareableDocumentList
                   documents={documents}
                   displayMode={displayMode}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2860,9 +2860,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/ui@npm:1.6.7":
-  version: 1.6.7
-  resolution: "@filigran/ui@npm:1.6.7"
+"@filigran/ui@npm:1.6.8":
+  version: 1.6.8
+  resolution: "@filigran/ui@npm:1.6.8"
   dependencies:
     "@dnd-kit/core": "npm:6.3.1"
     "@dnd-kit/modifiers": "npm:9.0.0"
@@ -2906,7 +2906,7 @@ __metadata:
     react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0
     react-hook-form: ^7.68.0
     zod: ^4.1.13
-  checksum: 10/5af14cd9e443d1f21a6d82096993ffd52e29780c7d6c9f7cdce34676950cf751542c1ee9c0dd2eeee8ec668f8c791c54dc0008dc4eba42944e4619da646dfa48
+  checksum: 10/f6a05c3b12b4969021a3494d81376de3b309e5473999517e47cecfcfa565dd1a150bc6bf931abd4a4b26f281438ab034ddea89132aaf4d69908d293747d18cd0
   languageName: node
   linkType: hard
 
@@ -8916,7 +8916,7 @@ __metadata:
   resolution: "@xtm-hub/frontend@workspace:apps/frontend"
   dependencies:
     "@filigran/icon": "npm:0.24.3"
-    "@filigran/ui": "npm:1.6.7"
+    "@filigran/ui": "npm:1.6.8"
     "@graphql-codegen/cli": "catalog:"
     "@graphql-codegen/typescript": "catalog:"
     "@graphql-codegen/typescript-operations": "npm:4.6.1"


### PR DESCRIPTION
# Context
> Remove the count in the accordion that is confusing + open all accordions by default

## How to test
- Navigate on the lib service 
- On accordion, you hsould not see the count in the accordions 
- All accordions should be opened by default

<img width="1873" height="625" alt="image" src="https://github.com/user-attachments/assets/554295de-a2e9-49d6-b771-a0e6983b2b61" />

New accordions: 
<img width="1748" height="423" alt="image" src="https://github.com/user-attachments/assets/10147933-243e-4430-a0c0-c8aaa0f50a52" />


<img width="1850" height="386" alt="image" src="https://github.com/user-attachments/assets/94835825-2c0d-4068-939b-a51eafacae67" />

## Related issues

- Related to #3174

# Checklist

## Quality

- [X] I consider this work complete and ready for review
- [X] I tested all features and edge cases
- [X] I refactored code where necessary to improve quality
- [X] I made sure my code meets development guidelines
- [X] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [X] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [X] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [X] Local manual tests
