### PR TITLE
feat(homepage): add newest resources on public homepage (#3179)

### DIFF
--- a/apps/e2e/tests/model/user.pageModel.ts
+++ b/apps/e2e/tests/model/user.pageModel.ts
@@ -19,7 +19,10 @@ export default class UserPage {
     await this.page
       .getByRole('button', { name: 'Settings', exact: true })
       .click();
-    await this.page.getByRole('link', { name: 'Users' }).click();
+    await this.page
+      .getByRole('navigation')
+      .getByRole('link', { name: 'Users', exact: true })
+      .click();
 
     await expect(
       this.page.getByRole('heading', { level: 1 }).locator(':scope.sr-only')

--- a/apps/e2e/tests/tests_files/user.spec.ts
+++ b/apps/e2e/tests/tests_files/user.spec.ts
@@ -83,7 +83,10 @@ test.describe('User Management', () => {
     page,
   }) => {
     await loginPage.navigateToAndLogin(TEST_USER.adminThales);
-    await page.getByRole('link', { name: 'Users' }).click();
+    await page
+      .getByRole('navigation')
+      .getByRole('link', { name: 'Users', exact: true })
+      .click();
     await page.getByRole('button', { name: 'Add user' }).click();
     await expect(
       page.getByRole('textbox', { name: 'First name' })
@@ -112,7 +115,10 @@ test.describe('User Management', () => {
     const pendingUserNodeId = Buffer.from(`User:${userId}`).toString('base64');
 
     await loginPage.navigateToAndLogin(TEST_USER.adminThales);
-    await page.getByRole('link', { name: 'Users' }).click();
+    await page
+      .getByRole('navigation')
+      .getByRole('link', { name: 'Users', exact: true })
+      .click();
     await page.goto(
       `/app/manage/user?action=approve&user_id=${pendingUserNodeId}`
     );

--- a/apps/frontend/src/components/homepage/Homepage.tsx
+++ b/apps/frontend/src/components/homepage/Homepage.tsx
@@ -1,6 +1,7 @@
 import BlueBlurDecoration from '@/components/homepage/BlueBlurDecoration';
 import { PublicLocale } from '@/i18n/config';
 import MostDeployedResources from './resources/MostDeployedResources';
+import NewestResources from './resources/NewestResources';
 import XtmRoadmap from './roadmap/XtmRoadmap';
 import XtmPlatform from './xtm-platform/XtmPlatform';
 
@@ -13,6 +14,7 @@ const Homepage = ({ paramsLocale }: HomepageProps) => {
       <div className="flex flex-col gap-xxl">
         <XtmPlatform />
         <XtmRoadmap paramsLocale={paramsLocale} />
+        <NewestResources paramsLocale={paramsLocale} />
         <MostDeployedResources paramsLocale={paramsLocale} />
       </div>
     </div>

--- a/apps/frontend/src/components/homepage/resources/NewestResources.tsx
+++ b/apps/frontend/src/components/homepage/resources/NewestResources.tsx
@@ -1,4 +1,5 @@
 import HomepageResourceList from '@/components/homepage/resources/HomepageResourceList';
+import { PublicLocale } from '@/i18n/config';
 import { serverGraphqlFetch } from '@/lib/server-graphql-fetch';
 import {
   NewestDocumentsQueryDocument,
@@ -13,11 +14,13 @@ const NEWEST_LIMIT = 8;
 type NewestResourcesProps = {
   platformIdentifiers?: PlatformIdentifier[];
   isAuthenticated?: boolean;
+  paramsLocale?: PublicLocale;
 };
 
 const NewestResources = async ({
   platformIdentifiers,
   isAuthenticated = false,
+  paramsLocale,
 }: NewestResourcesProps) => {
   const t = await getTranslations('HomePage.XtmNewestResources');
 
@@ -38,6 +41,7 @@ const NewestResources = async ({
       title={t('Title')}
       documents={data.newestDocuments}
       isAuthenticated={isAuthenticated}
+      paramsLocale={paramsLocale}
     />
   );
 };


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

Add newest resources section on public homepage to match private homepage.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

- load the public homepage
- check that newest resources section is displayed (with same resources as private homepage)

<img width="3024" height="1608" alt="image" src="https://github.com/user-attachments/assets/3ad2f616-4526-425f-a6b1-723b3a8abe50" />

## Related issues

- Related to #3179

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [x] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.