### PR TITLE
fix(cybersecurity-solutions): return 404 for non-public service instances (#3196)

### DIFF
--- a/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/[slug]/[docSlug]/page.tsx
+++ b/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/[slug]/[docSlug]/page.tsx
@@ -8,8 +8,6 @@ import { BreadcrumbNav } from '@/components/ui/BreadcrumbNav';
 import { ShareLinkButton } from '@/components/ui/share-link/ShareLinkButton';
 import type { PublicLocale } from '@/i18n/config';
 import { RelayProvider } from '@/relay/relay-provider';
-import { serverFetchGraphQL } from '@/relay/server-portal-api-fetch';
-import { PUBLIC_PAGE_REVALIDATE_SECONDS } from '@/utils/constant';
 import { filterDocumentImages, findDocumentLogo } from '@/utils/documents';
 import { formatPersonNames } from '@/utils/format/name';
 import {
@@ -19,6 +17,7 @@ import {
   stringifyJsonLd,
 } from '@/utils/generate-metadata';
 import { PUBLIC_CYBERSECURITY_SOLUTIONS_PATH } from '@/utils/path/constant';
+import { fetchSeoServiceInstanceBySlug } from '@/utils/seo-service-instance/utils/seo-service-instance.server.utils';
 import { localeMap } from '@/utils/shareable-resources/shareable-resources.consts';
 import {
   isConnectorResource,
@@ -35,10 +34,6 @@ import {
 import { LogoFiligranIcon } from '@filigran/icon';
 import { MarkdownRenderer } from '@filigran/ui/clients';
 import { Button } from '@filigran/ui/servers';
-import { seoServiceInstanceFragment$data } from '@generated/seoServiceInstanceFragment.graphql';
-import SeoServiceInstanceQuery, {
-  seoServiceInstanceQuery,
-} from '@generated/seoServiceInstanceQuery.graphql';
 import { Metadata } from 'next';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 import Image from 'next/image';
@@ -66,18 +61,7 @@ const FALLBACK_DESCRIPTION_KEYS: Record<ServiceSlug, string> = {
 const getPageData = cache(async (serviceSlug: string, docSlug: string) => {
   const baseUrl = await getBaseUrl();
 
-  const serviceResponse = await serverFetchGraphQL<seoServiceInstanceQuery>(
-    SeoServiceInstanceQuery,
-    { slug: serviceSlug },
-    { cache: undefined, next: { revalidate: PUBLIC_PAGE_REVALIDATE_SECONDS } }
-  );
-
-  const serviceInstance = serviceResponse.data
-    .seoServiceInstance as unknown as seoServiceInstanceFragment$data;
-
-  if (!serviceInstance) {
-    notFound();
-  }
+  const serviceInstance = await fetchSeoServiceInstanceBySlug(serviceSlug);
 
   // Reuses the same cached fetch as the parent list/SEO page, so this is a
   // free lookup in the common case. It lets us reject unknown/guessed

--- a/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/[slug]/page.tsx
+++ b/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/[slug]/page.tsx
@@ -15,18 +15,14 @@ import {
   stringifyJsonLd,
 } from '@/utils/generate-metadata';
 import { PUBLIC_CYBERSECURITY_SOLUTIONS_PATH } from '@/utils/path/constant';
+import { fetchSeoServiceInstanceBySlug } from '@/utils/seo-service-instance/utils/seo-service-instance.server.utils';
 import { ServiceSlug } from '@/utils/shareable-resources/shareable-resources.types';
 import { fetchAllDocuments } from '@/utils/shareable-resources/utils/shareable-resources.server.utils';
-import { seoServiceInstanceFragment$data } from '@generated/seoServiceInstanceFragment.graphql';
 import SeoServiceInstanceMetadataQuery, {
   seoServiceInstanceMetadataQuery,
 } from '@generated/seoServiceInstanceMetadataQuery.graphql';
-import SeoServiceInstanceQuery, {
-  seoServiceInstanceQuery,
-} from '@generated/seoServiceInstanceQuery.graphql';
 import { Metadata } from 'next';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
-import { notFound } from 'next/navigation';
 import { cache } from 'react';
 import { PublicDocumentListPageLoader } from './public-document-list-page-loader';
 
@@ -36,18 +32,7 @@ import { PublicDocumentListPageLoader } from './public-document-list-page-loader
 const getPageData = cache(async (slug: string, locale: PublicLocale) => {
   const baseUrl = await getBaseUrl();
 
-  const serviceResponse = await serverFetchGraphQL<seoServiceInstanceQuery>(
-    SeoServiceInstanceQuery,
-    { slug },
-    { cache: undefined, next: { revalidate: PUBLIC_PAGE_REVALIDATE_SECONDS } }
-  );
-
-  const serviceInstance = serviceResponse.data
-    .seoServiceInstance as unknown as seoServiceInstanceFragment$data;
-
-  if (!serviceInstance) {
-    notFound();
-  }
+  const serviceInstance = await fetchSeoServiceInstanceBySlug(slug);
 
   const seoMetadataResponse =
     await serverFetchGraphQL<seoServiceInstanceMetadataQuery>(

--- a/apps/frontend/app/not-found.tsx
+++ b/apps/frontend/app/not-found.tsx
@@ -10,6 +10,7 @@ const NotFound = () => {
   return (
     <RelayProvider>
       <PublicPathError
+        shouldLog={false}
         error={{
           name: 'PageNotFoundError',
           message: `An user try to reach this unknown path: ${pathname}`,

--- a/apps/frontend/setup-vitest.ts
+++ b/apps/frontend/setup-vitest.ts
@@ -13,6 +13,7 @@ import '@testing-library/jest-dom';
 import { useIsFeatureEnabled } from '@/hooks/use-is-feature-enabled';
 import { useRegisteredPlatforms } from '@/hooks/use-registered-platforms';
 import {
+  notFound,
   useParams,
   usePathname,
   useRouter,
@@ -46,6 +47,7 @@ vi.mock('next/navigation', async (importOriginal) => ({
   useRouter: vi.fn(),
   useParams: vi.fn(),
   useSearchParams: vi.fn(),
+  notFound: vi.fn(),
 }));
 
 vi.mock('next-intl', async (importOriginal) => ({
@@ -87,6 +89,9 @@ const setDefaultGlobalMocks = () => {
   vi.mocked(useSearchParams).mockReturnValue(
     new URLSearchParams() as unknown as ReturnType<typeof useSearchParams>
   );
+  vi.mocked(notFound).mockImplementation(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  });
   vi.mocked(registerClientEnvironment).mockImplementation(
     (environment: RegisterClientEnvironment) => {
       mockedClientEnvironment = environment;

--- a/apps/frontend/src/components/PublicPathError.test.tsx
+++ b/apps/frontend/src/components/PublicPathError.test.tsx
@@ -1,0 +1,62 @@
+import { logFrontendError } from '@/components/error-frontend-log.graphql';
+import PublicPathError from '@/components/PublicPathError';
+import { isProduction } from '@/lib/utils';
+import testRender from '@/utils/test/test-render';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/utils')>()),
+  isProduction: vi.fn(),
+}));
+
+vi.mock('@public/logo_xtm_hub_light.svg', () => ({
+  default: () => <svg data-testid="logo-light" />,
+}));
+
+vi.mock('@public/logo_xtm_hub_dark.svg', () => ({
+  default: () => <svg data-testid="logo-dark" />,
+}));
+
+describe('PublicPathError', () => {
+  beforeEach(() => {
+    vi.mocked(isProduction).mockReturnValue(true);
+  });
+
+  it('reports the error via logFrontendError in production by default (genuine unexpected errors, e.g. an error.tsx boundary)', () => {
+    testRender(
+      <PublicPathError
+        error={{ name: 'Error', message: 'boom', stack: 'stack-trace' }}
+      />
+    );
+
+    expect(logFrontendError).toHaveBeenCalledWith(
+      expect.anything(),
+      'boom',
+      'stack-trace',
+      undefined
+    );
+  });
+
+  it('does not report the error when shouldLog is false (expected 404s, e.g. the root not-found.tsx)', () => {
+    testRender(
+      <PublicPathError
+        shouldLog={false}
+        error={{ name: 'PageNotFoundError', message: 'unknown path' }}
+      />
+    );
+
+    expect(logFrontendError).not.toHaveBeenCalled();
+  });
+
+  it('never reports outside of production, even when shouldLog is true', () => {
+    vi.mocked(isProduction).mockReturnValue(false);
+
+    testRender(
+      <PublicPathError
+        error={{ name: 'Error', message: 'boom' }}
+      />
+    );
+
+    expect(logFrontendError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/components/PublicPathError.tsx
+++ b/apps/frontend/src/components/PublicPathError.tsx
@@ -8,13 +8,25 @@ import { useRelayEnvironment } from 'react-relay';
 
 interface PublicPathErrorProps {
   error: Error & { digest?: string; componentStack?: string };
+  /**
+   * Whether to report this error to the backend via `logFrontendError`.
+   * Defaults to `true` for genuine unexpected errors (e.g. errors caught by
+   * an `error.tsx` boundary). Callers that render this component for an
+   * *expected* "not found" state (e.g. the root `not-found.tsx`, reached via
+   * `notFound()` for an unknown/non-public slug) should pass `false` so a
+   * normal 404 doesn't get reported as an application error.
+   */
+  shouldLog?: boolean;
 }
 
-const PublicPathError = ({ error }: PublicPathErrorProps) => {
+const PublicPathError = ({
+  error,
+  shouldLog = true,
+}: PublicPathErrorProps) => {
   const env = useRelayEnvironment();
   const t = useTranslations();
   useEffect(() => {
-    if (isProduction()) {
+    if (shouldLog && isProduction()) {
       logFrontendError(
         env,
         error.message || 'Unknown error',

--- a/apps/frontend/src/utils/seo-service-instance/utils/seo-service-instance.server.utils.test.ts
+++ b/apps/frontend/src/utils/seo-service-instance/utils/seo-service-instance.server.utils.test.ts
@@ -1,0 +1,44 @@
+import { serverFetchGraphQL } from '@/relay/server-portal-api-fetch';
+import { fetchSeoServiceInstanceBySlug } from '@/utils/seo-service-instance/utils/seo-service-instance.server.utils';
+import { notFound } from 'next/navigation';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/relay/server-portal-api-fetch', () => ({
+  serverFetchGraphQL: vi.fn(),
+}));
+
+describe('fetchSeoServiceInstanceBySlug', () => {
+  it('returns the service instance when the query resolves with data', async () => {
+    const serviceInstance = { id: 'service-1', slug: 'opencti' };
+    vi.mocked(serverFetchGraphQL).mockResolvedValue({
+      data: { seoServiceInstance: serviceInstance },
+    } as never);
+
+    await expect(fetchSeoServiceInstanceBySlug('opencti')).resolves.toEqual(
+      serviceInstance
+    );
+    expect(notFound).not.toHaveBeenCalled();
+  });
+
+  it('calls Next.js notFound() instead of letting the error bubble up when the backend throws SERVICE_NOT_FOUND (non-public or unknown slug)', async () => {
+    vi.mocked(serverFetchGraphQL).mockRejectedValue(
+      new Error('SERVICE_NOT_FOUND')
+    );
+
+    await expect(
+      fetchSeoServiceInstanceBySlug('non-public-or-unknown-slug')
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFound).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls Next.js notFound() when the query resolves without an error but with no service instance', async () => {
+    vi.mocked(serverFetchGraphQL).mockResolvedValue({
+      data: { seoServiceInstance: null },
+    } as never);
+
+    await expect(
+      fetchSeoServiceInstanceBySlug('unknown-slug')
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFound).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/frontend/src/utils/seo-service-instance/utils/seo-service-instance.server.utils.ts
+++ b/apps/frontend/src/utils/seo-service-instance/utils/seo-service-instance.server.utils.ts
@@ -1,8 +1,13 @@
 import { serverFetchGraphQL } from '@/relay/server-portal-api-fetch';
+import { PUBLIC_PAGE_REVALIDATE_SECONDS } from '@/utils/constant';
 import { seoServiceInstanceFragment$data } from '@generated/seoServiceInstanceFragment.graphql';
+import SeoServiceInstanceQuery, {
+  seoServiceInstanceQuery,
+} from '@generated/seoServiceInstanceQuery.graphql';
 import SeoServiceInstancesQuery, {
   seoServiceInstancesQuery,
 } from '@generated/seoServiceInstancesQuery.graphql';
+import { notFound } from 'next/navigation';
 
 export async function fetchSeoServiceInstances(): Promise<
   seoServiceInstanceFragment$data[]
@@ -15,6 +20,41 @@ export async function fetchSeoServiceInstances(): Promise<
 
   return response.data
     .seoServiceInstances as unknown as seoServiceInstanceFragment$data[];
+}
+
+/**
+ * Fetches the public SEO service instance for a slug. `seoServiceInstance` is
+ * a non-nullable GraphQL field, so when the backend can't find a public
+ * ServiceInstance for this slug it returns a GraphQL error (SERVICE_NOT_FOUND)
+ * rather than a null field. The relay network layer turns that into a thrown
+ * Error, so we must catch it here and resolve it as a normal 404 instead of
+ * letting it bubble up as an unhandled exception.
+ */
+export async function fetchSeoServiceInstanceBySlug(
+  slug: string
+): Promise<seoServiceInstanceFragment$data> {
+  let response;
+  try {
+    response = await serverFetchGraphQL<seoServiceInstanceQuery>(
+      SeoServiceInstanceQuery,
+      { slug },
+      {
+        cache: undefined,
+        next: { revalidate: PUBLIC_PAGE_REVALIDATE_SECONDS },
+      }
+    );
+  } catch {
+    notFound();
+  }
+
+  const serviceInstance = response.data
+    .seoServiceInstance as unknown as seoServiceInstanceFragment$data;
+
+  if (!serviceInstance) {
+    notFound();
+  }
+
+  return serviceInstance;
 }
 
 export async function fetchVisibleServiceSlugs(): Promise<string[]> {


### PR DESCRIPTION
## Root cause

`seoServiceInstance` is a non-nullable GraphQL field, so when a slug refers to a non-public or unknown service instance, the backend throws a `SERVICE_NOT_FOUND` error. That error is raised by `networkFetch` before the page's `notFound()` null-check ever runs, so non-public/unknown slugs ended up hitting the `error.tsx` boundary and logging a spurious frontend error instead of returning a clean 404.

There's a second, related issue: even after converting this to a proper `notFound()` call, Next.js renders the root `app/not-found.tsx` for it — which also renders `PublicPathError`, and that component unconditionally called `logFrontendError` in production. So every normal 404 (not just this one) was still being reported as an application error.

## Fix

- Added a `fetchSeoServiceInstanceBySlug` helper that wraps the fetch in a `try/catch` and calls `notFound()` when the service instance can't be resolved. Used in `[slug]/page.tsx` and `[slug]/[docSlug]/page.tsx`.
- Added a `shouldLog` prop to `PublicPathError` (default `true`, preserving today's behavior for genuine unexpected errors caught by `error.tsx` boundaries) and pass `shouldLog={false}` from `app/not-found.tsx`, so expected 404s are no longer reported via `logFrontendError`.
- Added unit tests covering both the `notFound()` behavior of `fetchSeoServiceInstanceBySlug` and the `shouldLog` gating of `PublicPathError`.

Fixes #3196
