### PR TITLE
feat(connectors): display only latest connectors (#3204)

### DIFF
--- a/apps/backend/src/__generated__/resolvers-types.ts
+++ b/apps/backend/src/__generated__/resolvers-types.ts
@@ -746,6 +746,7 @@ export enum EpicType {
 }
 
 export enum FeatureFlag {
+  DecouplingConnectors = 'DECOUPLING_CONNECTORS',
   Dummy = 'DUMMY',
   XtmPlatformTrial = 'XTM_PLATFORM_TRIAL'
 }

--- a/apps/backend/src/modules/document/domain/document.domain.test.ts
+++ b/apps/backend/src/modules/document/domain/document.domain.test.ts
@@ -20,6 +20,10 @@ import {
   OrderingMode,
 } from '../../../__generated__/resolvers-types';
 import type { DocumentMetadataKey } from '../../../model/kanel/public/DocumentMetadata';
+import {
+  TAG_DECOUPLING,
+  TAG_LATEST,
+} from '../../shareable-resource/manifest-fragment/manifest-fragment.helper';
 import { OPENAEV_SCENARIO_DOCUMENT_TYPE } from '../../shareable-resource/openaev/scenario/scenario.model';
 import { OPENCTI_CUSTOM_VIEW_DOCUMENT_TYPE } from '../../shareable-resource/opencti/custom-view/custom-view.model';
 import { IngestManifestDomain } from '../../shareable-resource/opencti/integration/ingest-manifest/ingest-manifest.domain';
@@ -49,8 +53,16 @@ import {
   PLATFORM_ORGANIZATION_UUID,
   SYSTEM_USER_UUID,
 } from '../../../portal.const';
+import { isFeatureEnabled } from '../../../utils/feature-flag.util';
 import { DocumentUploadsHelper } from '../document.uploads.helper';
 import { DocumentDomain } from './document.domain';
+
+// isFeatureEnabled is mocked (defaulting to disabled) so that tests are deterministic and
+// independent of the local `enabled_features` config (which may enable everything, e.g. via a
+// wildcard in a developer's local.json).
+vi.mock('../../../utils/feature-flag.util', () => ({
+  isFeatureEnabled: vi.fn(() => false),
+}));
 
 describe('document domain', () => {
   const minioFileMock = {
@@ -403,6 +415,62 @@ describe('document domain', () => {
             }),
           ])
         );
+      });
+    });
+
+    describe('decoupling connectors feature flag', () => {
+      beforeEach(() => {
+        vi.mocked(isFeatureEnabled).mockReturnValue(true);
+      });
+
+      afterEach(() => {
+        vi.mocked(isFeatureEnabled).mockReturnValue(false);
+      });
+
+      let connectorSlugCounter = 0;
+      const createConnector = async (tags: string[]): Promise<Document> => {
+        connectorSlugCounter += 1;
+        const doc = await TestHelper.document.create({
+          type: OPENCTI_INTEGRATION_DOCUMENT_TYPE,
+          service_instance_id: INTEGRATION_SERVICE_INSTANCE_ID,
+          slug: `decoupling-connector-${connectorSlugCounter}`,
+          active: true,
+          tags,
+        });
+        await TestHelper.documentMetadata.create({
+          document_id: doc.id,
+          key: DocumentMetadataKeyCode.IntegrationType as unknown as DocumentMetadataKey,
+          value: IntegrationType.Connector,
+        });
+        return doc;
+      };
+
+      it('should only return connectors tagged with both latest and decoupling when the flag is enabled, leaving other integration types untouched', async () => {
+        const latestDecoupledConnector = await createConnector([
+          TAG_LATEST,
+          TAG_DECOUPLING,
+        ]);
+        const decoupledOnlyConnector = await createConnector([TAG_DECOUPLING]);
+        const legacyConnector = await createConnector([]);
+
+        const connection =
+          await DocumentDomain.loadParentDocumentsByServiceInstance(
+            OPENCTI_INTEGRATION_DOCUMENT_TYPE,
+            {
+              orderBy: DocumentOrdering.CreatedAt,
+              orderMode: OrderingMode.Desc,
+              first: 10,
+              serviceInstanceId: INTEGRATION_SERVICE_INSTANCE_ID,
+            },
+            INTEGRATION_METADATA_KEYS
+          );
+
+        const ids = connection.edges.map((edge) => edge.node.id);
+        expect(ids).toContain(latestDecoupledConnector.id);
+        expect(ids).not.toContain(decoupledOnlyConnector.id);
+        expect(ids).not.toContain(legacyConnector.id);
+        // Non-connector integration types are unaffected by the flag.
+        expect(ids).toContain(csvFeed.id);
       });
     });
 

--- a/apps/backend/src/modules/document/domain/document.domain.ts
+++ b/apps/backend/src/modules/document/domain/document.domain.ts
@@ -3,6 +3,7 @@ import { db, dbRaw, paginate } from '../../../../knexfile';
 import {
   DocumentConnection,
   DocumentMetadataKeyCode,
+  FeatureFlag,
   IntegrationType,
   Organization,
   QueryDocumentsArgs,
@@ -17,11 +18,13 @@ import {
 import { ServiceInstanceId } from '../../../model/kanel/public/ServiceInstance';
 import User, { UserId } from '../../../model/kanel/public/User';
 import { UnknownErrorCode } from '../../../utils/error/error.code';
+import { isFeatureEnabled } from '../../../utils/feature-flag.util';
 import { omit } from '../../../utils/utils';
 import { isLtsVersion } from '../../../utils/versioning';
 import {
   ConnectorV2,
   INTEGRATION_CONNECTOR_V2_METADATA_KEYS,
+  OPENCTI_INTEGRATION_DOCUMENT_TYPE,
 } from '../../shareable-resource/opencti/integration/integration.model';
 import { Document, DOCUMENT_TYPE, WithDocumentId } from '../document.helper';
 
@@ -45,6 +48,7 @@ import { stripNulls } from '../../../utils/typescript';
 import {
   ManifestFragmentHelper,
   TAG_DECOUPLING,
+  TAG_LATEST,
 } from '../../shareable-resource/manifest-fragment/manifest-fragment.helper';
 import { isUserRestrictedToActiveDocument } from '../document.security';
 import {
@@ -61,6 +65,40 @@ const excludeDecouplingTag = (query: Knex.QueryBuilder) =>
     `NOT (? ILIKE ANY(COALESCE("Document"."tags", ARRAY[]::text[])))`,
     [TAG_DECOUPLING]
   );
+
+// Matches rows whose IntegrationType metadata is "connector".
+const buildIsConnectorSubquery = (query: Knex.QueryBuilder) =>
+  query
+    .select(dbRaw('1'))
+    .from('Document_Metadata')
+    .whereRaw('"Document_Metadata"."document_id" = "Document"."id"')
+    .andWhere('Document_Metadata.key', DocumentMetadataKeyCode.IntegrationType)
+    .andWhere('Document_Metadata.value', IntegrationType.Connector);
+
+// For connector documents, only keep those tagged with both TAG_LATEST and TAG_DECOUPLING
+// (case-insensitive). Other integration subtypes keep the default excludeDecouplingTag behaviour.
+// Used behind the DECOUPLING_CONNECTORS feature flag.
+const restrictConnectorsToLatestDecoupling = (query: Knex.QueryBuilder) =>
+  query.where((outer) => {
+    outer
+      .where((nonConnectorBuilder) => {
+        nonConnectorBuilder
+          .whereNotExists(buildIsConnectorSubquery)
+          .modify(excludeDecouplingTag);
+      })
+      .orWhere((connectorBuilder) => {
+        connectorBuilder
+          .whereExists(buildIsConnectorSubquery)
+          .whereRaw(
+            `? ILIKE ANY(COALESCE("Document"."tags", ARRAY[]::text[]))`,
+            [TAG_LATEST]
+          )
+          .whereRaw(
+            `? ILIKE ANY(COALESCE("Document"."tags", ARRAY[]::text[]))`,
+            [TAG_DECOUPLING]
+          );
+      });
+  });
 
 export type DocumentData<
   T extends DocumentModel,
@@ -292,7 +330,18 @@ export const DocumentDomain = {
       .tap(restrictDocumentToUserOrganization)
       .tap(restrictDocumentToAccessibleServiceInstance)
       .where(field)
-      .modify(excludeDecouplingTag);
+      .modify((qb) => {
+        const isIntegrationsListing =
+          field['Document.type'] === OPENCTI_INTEGRATION_DOCUMENT_TYPE;
+        if (
+          isIntegrationsListing &&
+          isFeatureEnabled(FeatureFlag.DecouplingConnectors)
+        ) {
+          restrictConnectorsToLatestDecoupling(qb);
+        } else {
+          excludeDecouplingTag(qb);
+        }
+      });
 
     if (
       field['Document.service_instance_id'] &&

--- a/apps/backend/src/modules/document/domain/document.domain.ts
+++ b/apps/backend/src/modules/document/domain/document.domain.ts
@@ -59,46 +59,67 @@ import {
 type UseCaseValue = UseCaseId | string;
 type SolutionCategoryValue = SolutionCategoryId | string;
 
-// Excludes documents tagged with TAG_DECOUPLING (case-insensitive), regardless of casing.
+// Hides documents tagged TAG_DECOUPLING. Tags are lowercase, so @> is a safe indexable
+// replacement for ILIKE ANY.
 const excludeDecouplingTag = (query: Knex.QueryBuilder) =>
-  query.whereRaw(
-    `NOT (? ILIKE ANY(COALESCE("Document"."tags", ARRAY[]::text[])))`,
-    [TAG_DECOUPLING]
-  );
+  query.whereRaw(`NOT ("Document"."tags" @> ARRAY[?]::text[])`, [
+    TAG_DECOUPLING,
+  ]);
 
-// Matches rows whose IntegrationType metadata is "connector".
-const buildIsConnectorSubquery = (query: Knex.QueryBuilder) =>
-  query
-    .select(dbRaw('1'))
-    .from('Document_Metadata')
-    .whereRaw('"Document_Metadata"."document_id" = "Document"."id"')
-    .andWhere('Document_Metadata.key', DocumentMetadataKeyCode.IntegrationType)
-    .andWhere('Document_Metadata.value', IntegrationType.Connector);
-
-// For connector documents, only keep those tagged with both TAG_LATEST and TAG_DECOUPLING
-// (case-insensitive). Other integration subtypes keep the default excludeDecouplingTag behaviour.
-// Used behind the DECOUPLING_CONNECTORS feature flag.
+// Connectors: require TAG_LATEST + TAG_DECOUPLING. Non-connectors: fall back to
+// excludeDecouplingTag. Gated by DECOUPLING_CONNECTORS.
 const restrictConnectorsToLatestDecoupling = (query: Knex.QueryBuilder) =>
-  query.where((outer) => {
-    outer
-      .where((nonConnectorBuilder) => {
-        nonConnectorBuilder
-          .whereNotExists(buildIsConnectorSubquery)
-          .modify(excludeDecouplingTag);
-      })
-      .orWhere((connectorBuilder) => {
-        connectorBuilder
-          .whereExists(buildIsConnectorSubquery)
-          .whereRaw(
-            `? ILIKE ANY(COALESCE("Document"."tags", ARRAY[]::text[]))`,
-            [TAG_LATEST]
-          )
-          .whereRaw(
-            `? ILIKE ANY(COALESCE("Document"."tags", ARRAY[]::text[]))`,
-            [TAG_DECOUPLING]
-          );
-      });
-  });
+  query
+    // LEFT JOIN instead of two EXISTS subqueries (one negated, one not): computes
+    // "is connector" once per row. Safe from row duplication since (document_id, key)
+    // is Document_Metadata's primary key, so at most one row matches per document.
+    .leftJoin({ dm_integration_type: 'Document_Metadata' }, function () {
+      this.on('dm_integration_type.document_id', '=', 'Document.id').andOnVal(
+        'dm_integration_type.key',
+        DocumentMetadataKeyCode.IntegrationType
+      );
+    })
+    .where((outer) => {
+      outer
+        .where((nonConnectorBuilder) => {
+          nonConnectorBuilder
+            .whereRaw('"dm_integration_type"."value" IS DISTINCT FROM ?', [
+              IntegrationType.Connector,
+            ])
+            .modify(excludeDecouplingTag);
+        })
+        .orWhere((connectorBuilder) => {
+          connectorBuilder
+            .where('dm_integration_type.value', IntegrationType.Connector)
+            .whereRaw(`"Document"."tags" @> ARRAY[?, ?]::text[]`, [
+              TAG_LATEST,
+              TAG_DECOUPLING,
+            ]);
+        });
+    });
+
+// Applies DECOUPLING_CONNECTORS for queries scoped to a single document `type`.
+const applyDecouplingRestriction =
+  (type: string) => (query: Knex.QueryBuilder) => {
+    if (
+      type === OPENCTI_INTEGRATION_DOCUMENT_TYPE &&
+      isFeatureEnabled(FeatureFlag.DecouplingConnectors)
+    ) {
+      restrictConnectorsToLatestDecoupling(query);
+    } else {
+      excludeDecouplingTag(query);
+    }
+  };
+
+// Same as applyDecouplingRestriction, for mixed-type listings: no single `type` to
+// check, connectors self-select via their Document_Metadata IntegrationType.
+const applyDecouplingRestrictionForMixedTypes = (query: Knex.QueryBuilder) => {
+  if (isFeatureEnabled(FeatureFlag.DecouplingConnectors)) {
+    restrictConnectorsToLatestDecoupling(query);
+  } else {
+    excludeDecouplingTag(query);
+  }
+};
 
 export type DocumentData<
   T extends DocumentModel,
@@ -330,18 +351,7 @@ export const DocumentDomain = {
       .tap(restrictDocumentToUserOrganization)
       .tap(restrictDocumentToAccessibleServiceInstance)
       .where(field)
-      .modify((qb) => {
-        const isIntegrationsListing =
-          field['Document.type'] === OPENCTI_INTEGRATION_DOCUMENT_TYPE;
-        if (
-          isIntegrationsListing &&
-          isFeatureEnabled(FeatureFlag.DecouplingConnectors)
-        ) {
-          restrictConnectorsToLatestDecoupling(qb);
-        } else {
-          excludeDecouplingTag(qb);
-        }
-      });
+      .modify(applyDecouplingRestriction(field['Document.type'] as string));
 
     if (
       field['Document.service_instance_id'] &&
@@ -397,7 +407,7 @@ export const DocumentDomain = {
       .where('Document.slug', '=', slug)
       .where('Document.active', '=', true)
       .where('Document.type', '=', type)
-      .modify(excludeDecouplingTag)
+      .modify(applyDecouplingRestriction(type))
       .tap(restrictDocumentToPublicServiceInstance)
       .whereNotExists(function () {
         this.select('*')
@@ -473,7 +483,7 @@ export const DocumentDomain = {
       .tap(restrictServiceInstanceToPublic)
       .where('Document.active', '=', true)
       .where('Document.type', '=', type)
-      .modify(excludeDecouplingTag)
+      .modify(applyDecouplingRestriction(type))
       .modify((qb) => {
         if (orderResults) {
           qb.orderBy([
@@ -618,7 +628,7 @@ export const DocumentDomain = {
             '"Document_Children"."child_document_id" = "Document"."id"'
           );
       })
-      .modify(excludeDecouplingTag)
+      .modify(applyDecouplingRestrictionForMixedTypes)
       .tap(restrictDocumentToAccessibleServiceInstance)
       .modify((qb) => {
         if (documentTypes?.length) {

--- a/apps/backend/src/modules/settings/settings.graphql
+++ b/apps/backend/src/modules/settings/settings.graphql
@@ -1,6 +1,7 @@
 enum FeatureFlag {
   DUMMY
   XTM_PLATFORM_TRIAL
+  DECOUPLING_CONNECTORS
 }
 
 type PlatformProvider {

--- a/apps/frontend/graphql/generated.ts
+++ b/apps/frontend/graphql/generated.ts
@@ -754,6 +754,7 @@ export enum EpicType {
 }
 
 export enum FeatureFlag {
+  DecouplingConnectors = 'DECOUPLING_CONNECTORS',
   Dummy = 'DUMMY',
   XtmPlatformTrial = 'XTM_PLATFORM_TRIAL'
 }

--- a/apps/frontend/graphql/mocks.ts
+++ b/apps/frontend/graphql/mocks.ts
@@ -1682,7 +1682,7 @@ export const mockSettings = (overrides?: Partial<Settings>, _relationshipsToOmit
         __typename: 'Settings',
         base_url_front: overrides && overrides.hasOwnProperty('base_url_front') ? overrides.base_url_front! : 'sumo',
         environment: overrides && overrides.hasOwnProperty('environment') ? overrides.environment! : 'vicinus',
-        platform_feature_flags: overrides && overrides.hasOwnProperty('platform_feature_flags') ? overrides.platform_feature_flags! : [FeatureFlag.Dummy],
+        platform_feature_flags: overrides && overrides.hasOwnProperty('platform_feature_flags') ? overrides.platform_feature_flags! : [FeatureFlag.DecouplingConnectors],
         platform_providers: overrides && overrides.hasOwnProperty('platform_providers') ? overrides.platform_providers! : [relationshipsToOmit.has('PlatformProvider') ? {} as PlatformProvider : mockPlatformProvider({}, relationshipsToOmit)],
     };
 };

--- a/apps/frontend/schema.graphql
+++ b/apps/frontend/schema.graphql
@@ -1329,6 +1329,7 @@ type ServiceInstanceSubscription {
 enum FeatureFlag {
   DUMMY
   XTM_PLATFORM_TRIAL
+  DECOUPLING_CONNECTORS
 }
 
 type PlatformProvider {

--- a/bruno/manifest-fragment/IngestManifestFragments.bru
+++ b/bruno/manifest-fragment/IngestManifestFragments.bru
@@ -42,11 +42,12 @@ body:graphql:vars {
     "source_code": "https://github.com/OpenCTI-Platform/connectors/tree/master/external-import/misp",
     "manager_supported": true,
     "min_version": "7.260507.0",
-    "version": "7.260309.0-lts.6",
+    "version": "7.260309.0",
     "image_name": "opencti/connector-misp",
     "image_type": "EXTERNAL_IMPORT",
     "platform": "OpenCTI",
     "integration_type": "connector",
+    "solution_categories": ["Threat Intelligence Feed"],
     "additional_properties": {
       "max_confidence_level": 50
     },
@@ -91,6 +92,8 @@ docs {
   version / min_version: format major.date.patch[-lts.N], e.g. 7.260309.0-lts.5
   last_verified_date: ISO date string
   logo: base64 image, with "data:image/...;base64," prefix
+  solution_categories: required, must match existing SolutionCategory names (see 20260805093524_insert_solution_categories.js)
+  license_type / contact: optional
   
   Notes:
   - All fragments in one batch must be homogeneous (all LTS or all non-LTS).


### PR DESCRIPTION
# Context
This PR adds a `DECOUPLING_CONNECTORS` feature flag that, when enabled, restricts the connector library listing to only show **connectors** tagged with both `latest` and `decoupling`. Connectors missing either tag (decoupled-only, or legacy/untagged connectors) are hidden from the listing. Other integration subtypes (feeds, dashboards, etc.) are not affected and keep the previous `excludeDecouplingTag` filtering behaviour regardless of the flag.

> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

Key changes:
- Added `DECOUPLING_CONNECTORS` to the `FeatureFlag` enum (backend GraphQL schema + generated types, and the corresponding frontend generated types/mocks).
- Added `restrictConnectorsToLatestDecoupling` filtering logic in `document.domain.ts`, applied only to the integrations listing query (`OPENCTI_INTEGRATION_DOCUMENT_TYPE`) when the feature flag is enabled; falls back to the existing `excludeDecouplingTag` behaviour otherwise.
- Added unit tests covering the new behaviour: only connectors tagged with both `latest` and `decoupling` are returned when the flag is on, while other integration types remain untouched.
- Updated the `IngestManifestFragments.bru` sample payload (bumped connector version, added the required `solution_categories` field) and documented the new/optional manifest fragment fields.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

- Create a new connector by calling IngestManifestFragments
- Check that you can see the new connector
- You should not see the old connector


## Related issues

- Related to #3204

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.