### PR TITLE
feat(connected-products): display Trial tag and small css updates (#3124)

### DIFF
--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -365,7 +365,8 @@
       "GoToPlatform": "Go to {title}",
       "Details": "Details",
       "Documentation": "Documentation",
-      "ConnectPlatform": "Connect {platformName}"
+      "ConnectPlatform": "Connect {platformName}",
+      "Trial": "Trial"
     }
   },
   "HomePage": {

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -365,7 +365,8 @@
       "GoToPlatform": "Accéder à {title}",
       "Details": "Détails",
       "Documentation": "Documentation",
-      "ConnectPlatform": "Connecter {platformName}"
+      "ConnectPlatform": "Connecter {platformName}",
+      "Trial": "Essai"
     }
   },
   "HomePage": {

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -365,7 +365,8 @@
       "GoToPlatform": "{title} に移動",
       "Details": "詳細",
       "Documentation": "ドキュメント",
-      "ConnectPlatform": "{platformName} を接続"
+      "ConnectPlatform": "{platformName} を接続",
+      "Trial": "トライアル"
     }
   },
   "HomePage": {

--- a/apps/frontend/src/components/connected-products/ConnectedProductItem.test.tsx
+++ b/apps/frontend/src/components/connected-products/ConnectedProductItem.test.tsx
@@ -1,0 +1,116 @@
+import { ConnectedPlatform } from '@/components/connected-products/useConnectedPlatforms';
+import testRender from '@/utils/test/test-render';
+import {
+  PlatformContract,
+  ServiceDefinitionIdentifier,
+} from '@graphql/generated';
+import { screen } from '@testing-library/react';
+import { useTranslations } from 'next-intl';
+import { describe, expect, it } from 'vitest';
+import { ConnectedProductItem } from './ConnectedProductItem';
+
+const t = useTranslations();
+
+const buildPlatform = (
+  overrides: Partial<ConnectedPlatform> = {}
+): ConnectedPlatform => ({
+  id: 'platform-1',
+  platform_id: 'platform-1',
+  title: 'my openaev instance',
+  url: 'https://openaev.example.com',
+  contract: PlatformContract.Ce,
+  identifier: ServiceDefinitionIdentifier.OpenaevRegistration,
+  subscription: {
+    end_date: null,
+    start_date: null,
+    service_instance: { id: 'service-instance-1', name: 'instance' },
+  },
+  ...overrides,
+});
+
+describe('ConnectedProductItem', () => {
+  it('shows the Trial badge when the contract is trial', () => {
+    testRender(
+      <ConnectedProductItem
+        platform={buildPlatform({ contract: PlatformContract.Trial })}
+        t={t}
+      />
+    );
+
+    expect(
+      screen.getByText('Header.ConnectedProducts.Trial')
+    ).toBeInTheDocument();
+  });
+
+  it.each`
+    contract               | description
+    ${PlatformContract.Ce} | ${'CE'}
+    ${PlatformContract.Ee} | ${'EE'}
+  `(
+    'does not show the Trial badge when the contract is $description',
+    ({ contract }) => {
+      testRender(
+        <ConnectedProductItem
+          platform={buildPlatform({ contract })}
+          t={t}
+        />
+      );
+
+      expect(
+        screen.queryByText('Header.ConnectedProducts.Trial')
+      ).not.toBeInTheDocument();
+    }
+  );
+
+  it('renders the details button when a service instance is linked', () => {
+    testRender(
+      <ConnectedProductItem
+        platform={buildPlatform()}
+        t={t}
+      />
+    );
+
+    expect(
+      screen.getByLabelText('Header.ConnectedProducts.Details')
+    ).toBeInTheDocument();
+  });
+
+  it('does not render the details button when no service instance is linked', () => {
+    testRender(
+      <ConnectedProductItem
+        platform={buildPlatform({ subscription: null })}
+        t={t}
+      />
+    );
+
+    expect(
+      screen.queryByLabelText('Header.ConnectedProducts.Details')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the go-to-platform button when a url is set', () => {
+    testRender(
+      <ConnectedProductItem
+        platform={buildPlatform({ url: 'https://openaev.example.com' })}
+        t={t}
+      />
+    );
+
+    expect(
+      screen.getByLabelText('Header.ConnectedProducts.GoToPlatform')
+    ).toBeInTheDocument();
+  });
+
+  it('does not render the go-to-platform button when no url is set', () => {
+    testRender(
+      <ConnectedProductItem
+        platform={buildPlatform({ url: '' })}
+        t={t}
+      />
+    );
+
+    expect(
+      screen.queryByLabelText('Header.ConnectedProducts.GoToPlatform')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/connected-products/ConnectedProductItem.tsx
+++ b/apps/frontend/src/components/connected-products/ConnectedProductItem.tsx
@@ -8,8 +8,8 @@ import {
 import { UseTranslationsProps } from '@/i18n/config';
 import { APP_PATH } from '@/utils/path/constant';
 import { OpenInNewIcon, TextSnippetIcon } from '@filigran/icon';
-import { Button } from '@filigran/ui';
-import Image from 'next/image';
+import { Badge, Button } from '@filigran/ui';
+import { PlatformContract } from '@graphql/generated';
 import Link from 'next/link';
 
 interface ConnectedProductItemProps {
@@ -32,22 +32,21 @@ export const ConnectedProductItem = ({
     : undefined;
 
   return (
-    <div className="hover:cursor-default flex min-h-12 w-full items-center justify-between gap-m px-m py-s">
-      <div className="flex items-center gap-s">
-        {platformMeta?.logoUrl && (
-          <Image
-            src={platformMeta.logoUrl}
-            alt={platformMeta.name}
-            width={20}
-            height={20}
-            className="shrink-0 brightness-0 dark:brightness-0 dark:invert"
-          />
+    <div className="hover:cursor-default flex min-h-12 w-full items-center gap-m px-m py-s">
+      <div className="flex min-w-0 flex-1 items-center gap-s">
+        {platformMeta?.Icon && (
+          <platformMeta.Icon className="h-6 w-6 shrink-0" />
         )}
-        <span className="text-sm font-medium">
+        <span className="content-body-base">
           {platform.title ?? platformMeta?.name ?? platform.identifier}
         </span>
       </div>
-      <div className="flex items-center gap-xs">
+      {platform.contract === PlatformContract.Trial && (
+        <Badge className="border-none bg-feedback-info-secondary-transparency content-body-compact-medium">
+          {t('Header.ConnectedProducts.Trial')}
+        </Badge>
+      )}
+      <div className="flex w-16 items-center justify-end gap-xs">
         {detailPath && (
           <Button
             variant="secondary"


### PR DESCRIPTION

# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

On connected products dropdown, display a trial badge. 
Also minor css updates, like using Icon instead of image.


## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

When a registered platform as a trial license, display the 'trial' badge.
<img width="321" height="670" alt="image" src="https://github.com/user-attachments/assets/0625c638-5091-4d91-a042-8e1f5e98a70a" />
<img width="312" height="680" alt="image" src="https://github.com/user-attachments/assets/25e55bce-78ba-4fe1-ad7a-a07d71a44255" />




## Related issues

- Related to #3124

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [x] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [x] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.