### PR TITLE
fix(ci): skip app token creation for dependabot pull_request events (#3260)

### DIFF
--- a/.github/workflows/pr-issue-automation.yml
+++ b/.github/workflows/pr-issue-automation.yml
@@ -28,6 +28,12 @@ jobs:
     steps:
       - uses: actions/create-github-app-token@v3
         id: app-token
+        # Workflows triggered by a `pull_request` event opened by Dependabot run with
+        # read-only permissions and no access to repository secrets, so the private key
+        # would be empty and this step would fail. Skip it in that case; the app token is
+        # only needed by steps gated on other events (workflow_run, pull_request_target,
+        # pull_request_review) which retain full secrets access regardless of the actor.
+        if: ${{ !(github.event_name == 'pull_request' && github.actor == 'dependabot[bot]') }}
         with:
           app-id: ${{ vars.FILIGRANHQ_PROJECT_APP_ID }}
           private-key: ${{ secrets.FILIGRANHQ_PROJECT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## What

Skips the `create-github-app-token` step in `manage-pr-and-issues` when the workflow is triggered by a `pull_request` event opened by `dependabot[bot]`.

## Why

Fixes #3260.

`pull_request` events opened by Dependabot don't get access to repository secrets (same restriction as fork PRs), so `secrets.FILIGRANHQ_PROJECT_APP_PRIVATE_KEY` resolves to an empty string and `actions/create-github-app-token@v3` fails with:

```
Error: The 'private-key' input must be set to a non-empty string.
```

This permanently red the `manage-pr-and-issues` check on every Dependabot PR (e.g. #3259 — `dependabot/npm_and_yarn/browserslist-4.28.8`), blocking merges.

Steps that consume `steps.app-token.outputs.token` are already gated behind other event types (`workflow_run`, `pull_request_target`, `pull_request_review`), which keep full secrets access regardless of actor, so skipping token creation only for this specific case is safe.

## Validation

- Validated YAML syntax with `js-yaml`.
- Reviewed all downstream steps consuming `steps.app-token.outputs.token` to confirm none run on the initial Dependabot `pull_request` "opened" event.

## Follow-up

Once merged, rebase open Dependabot PRs (e.g. comment `@dependabot rebase` on #3259) so they pick up this fix and their checks can pass.