### PR TITLE
test(e2e): fix flaky capabilities subscription test (#3263)

### DIFF
--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -19,6 +19,10 @@ export default defineConfig({
   retries: 2,
   /* Parallel test is breaking tests */
   workers: 1,
+  /* Default is 30s. Some tests chain multiple login/logout cycles and
+   * form submissions (e.g. capabilities.spec.ts), which can get close to
+   * the default budget under CI load. Raise it suite-wide. */
+  timeout: 60_000,
   expect: {
     toHaveScreenshot: {
       maxDiffPixelRatio: 0.05,

--- a/apps/e2e/tests/tests_files/capabilities.spec.ts
+++ b/apps/e2e/tests/tests_files/capabilities.spec.ts
@@ -50,6 +50,12 @@ test.describe('Capabilities', () => {
     await loginPage.navigateToAndLogin();
   });
   test('Should add subscription with capabilities', async ({ page }) => {
+    // This test chains 5 full login/logout cycles plus several form
+    // submissions, so it regularly runs close to the default 30s test
+    // timeout in CI, causing it to intermittently time out mid-action
+    // (e.g. opening a menu or confirming a delete). Mark it slow to
+    // triple the timeout and give it enough headroom.
+    test.slow();
     await test.step("Add orga's sub + user with manage access", async () => {
       await servicePage.navigateToServiceListAdmin();
 

--- a/apps/e2e/tests/tests_files/capabilities.spec.ts
+++ b/apps/e2e/tests/tests_files/capabilities.spec.ts
@@ -50,12 +50,6 @@ test.describe('Capabilities', () => {
     await loginPage.navigateToAndLogin();
   });
   test('Should add subscription with capabilities', async ({ page }) => {
-    // This test chains 5 full login/logout cycles plus several form
-    // submissions, so it regularly runs close to the default 30s test
-    // timeout in CI, causing it to intermittently time out mid-action
-    // (e.g. opening a menu or confirming a delete). Mark it slow to
-    // triple the timeout and give it enough headroom.
-    test.slow();
     await test.step("Add orga's sub + user with manage access", async () => {
       await servicePage.navigateToServiceListAdmin();
 

--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -25,6 +25,7 @@ import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 
 import { OrganizationCapability } from '@graphql/generated';
+import { useQueryClient } from '@tanstack/react-query';
 import { usePathname, useRouter } from 'next/navigation';
 import { useCallback, useContext, useEffect, useState } from 'react';
 import { useMutation } from 'react-relay';
@@ -40,6 +41,7 @@ const HeaderComponent = ({ displayLogo }: HeaderComponentProps) => {
   const currentPath = usePathname();
   const router = useRouter();
   const t = useTranslations();
+  const queryClient = useQueryClient();
   const [commitLogoutMutation] = useMutation(LogoutMutation);
 
   // Legitimate effect: close the menu on route change.
@@ -59,11 +61,16 @@ const HeaderComponent = ({ displayLogo }: HeaderComponentProps) => {
         store.invalidateStore();
       },
       onCompleted() {
+        // Logout/login navigate client-side (no full page reload), so the
+        // React Query cache would otherwise survive a user switch in the
+        // same browser tab and could serve stale, user-scoped data (e.g.
+        // service capabilities) to whoever logs in next.
+        queryClient.clear();
         router.push('/');
         router.refresh();
       },
     });
-  }, [commitLogoutMutation, router]);
+  }, [commitLogoutMutation, queryClient, router]);
 
   const headerContent = (
     <>

--- a/apps/frontend/src/hooks/use-service-capability.test.tsx
+++ b/apps/frontend/src/hooks/use-service-capability.test.tsx
@@ -1,7 +1,9 @@
+import { PortalContext } from '@/components/me/AppPortalContext';
 import { useAdminByPass } from '@/hooks/use-portal-capability';
 import useServiceCapability, {
   useServiceCapabilityWithSubscriptionId,
 } from '@/hooks/use-service-capability';
+import { meContext_fragment$data } from '@generated/meContext_fragment.graphql';
 import { serviceInstance_fragment$data } from '@generated/serviceInstance_fragment.graphql';
 import {
   ServiceRestriction,
@@ -9,6 +11,7 @@ import {
   useServiceUserCapabilitiesQuery,
 } from '@graphql/generated';
 import { renderHook } from '@testing-library/react';
+import { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/hooks/use-portal-capability', () => ({
@@ -28,6 +31,17 @@ const UserServiceCapabilityId = 'user-service-capability-id';
 const UserServiceId = 'user-service-id';
 const GenericCapabilityId = 'generic-capability-id';
 const GenericCapabilityName = 'manage_access';
+const UserId = 'user-id';
+const OrganizationId = 'organization-id';
+
+const Me = {
+  id: UserId,
+  selected_organization_id: OrganizationId,
+} as meContext_fragment$data;
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <PortalContext.Provider value={{ me: Me }}>{children}</PortalContext.Provider>
+);
 
 const ServiceInstance: serviceInstance_fragment$data = {
   id: ServiceInstanceId,
@@ -78,8 +92,10 @@ describe('useServiceCapability', () => {
     });
 
     // When
-    const { result } = renderHook(() =>
-      useServiceCapability(ServiceRestriction.ManageAccess, ServiceInstance)
+    const { result } = renderHook(
+      () =>
+        useServiceCapability(ServiceRestriction.ManageAccess, ServiceInstance),
+      { wrapper }
     );
 
     // Then
@@ -111,11 +127,13 @@ describe('useServiceCapability', () => {
     });
 
     // When
-    const { result } = renderHook(() =>
-      useServiceCapabilityWithSubscriptionId(
-        ServiceRestriction.ManageAccess,
-        ServiceInstance
-      )
+    const { result } = renderHook(
+      () =>
+        useServiceCapabilityWithSubscriptionId(
+          ServiceRestriction.ManageAccess,
+          ServiceInstance
+        ),
+      { wrapper }
     );
 
     // Then
@@ -130,8 +148,10 @@ describe('useServiceCapability', () => {
     mockCapabilitiesQueryResult(undefined);
 
     // When
-    renderHook(() =>
-      useServiceCapability(ServiceRestriction.ManageAccess, ServiceInstance)
+    renderHook(
+      () =>
+        useServiceCapability(ServiceRestriction.ManageAccess, ServiceInstance),
+      { wrapper }
     );
 
     // Then
@@ -140,8 +160,44 @@ describe('useServiceCapability', () => {
       { service_instance_id: ServiceInstanceId },
       expect.objectContaining({
         enabled: true,
-        queryKey: ['service-user-capabilities', ServiceInstanceId],
+        queryKey: [
+          'service-user-capabilities',
+          ServiceInstanceId,
+          UserId,
+          OrganizationId,
+        ],
         staleTime: 10 * 60 * 1000,
+      })
+    );
+  });
+
+  it('should scope the cache key per user so switching user does not reuse a previous user cache entry', () => {
+    // Given
+    mockCapabilitiesQueryResult(undefined);
+    const otherUserWrapper = ({ children }: { children: ReactNode }) => (
+      <PortalContext.Provider value={{ me: { ...Me, id: 'other-user-id' } }}>
+        {children}
+      </PortalContext.Provider>
+    );
+
+    // When
+    renderHook(
+      () =>
+        useServiceCapability(ServiceRestriction.ManageAccess, ServiceInstance),
+      { wrapper: otherUserWrapper }
+    );
+
+    // Then
+    expect(useServiceUserCapabilitiesQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      { service_instance_id: ServiceInstanceId },
+      expect.objectContaining({
+        queryKey: [
+          'service-user-capabilities',
+          ServiceInstanceId,
+          'other-user-id',
+          OrganizationId,
+        ],
       })
     );
   });

--- a/apps/frontend/src/hooks/use-service-capability.tsx
+++ b/apps/frontend/src/hooks/use-service-capability.tsx
@@ -1,3 +1,4 @@
+import { PortalContext } from '@/components/me/AppPortalContext';
 import { useAdminByPass } from '@/hooks/use-portal-capability';
 import { portalGraphqlClient } from '@/lib/graphql-client';
 import { serviceInstance_fragment$data } from '@generated/serviceInstance_fragment.graphql';
@@ -5,7 +6,7 @@ import {
   ServiceRestriction,
   useServiceUserCapabilitiesQuery,
 } from '@graphql/generated';
-import { useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 
 const ServiceUserCapabilitiesStaleTime = 10 * 60 * 1000; // Cache: 10mns
 
@@ -19,6 +20,7 @@ const useServiceCapabilityData = (
   serviceInstance?: serviceInstance_fragment$data
 ): UseServiceCapabilityWithSubscriptionId => {
   const canBypass = useAdminByPass();
+  const { me } = useContext(PortalContext);
   const { data } = useServiceUserCapabilitiesQuery(
     portalGraphqlClient,
     {
@@ -26,10 +28,24 @@ const useServiceCapabilityData = (
     },
     {
       enabled: !!serviceInstance?.id,
-      queryKey: ['service-user-capabilities', serviceInstance?.id],
+      // The current user id and selected organization are part of the cache
+      // key (and not just the service instance id) because the response
+      // depends on which user/organization is making the request, not just
+      // the requested service. Logout/login happen via client-side
+      // navigation (no full page reload), so without this the query cache
+      // could otherwise serve one user's (or organization's) capabilities
+      // to a different user (or organization) that reuses the same
+      // browser tab, for up to ServiceUserCapabilitiesStaleTime.
+      queryKey: [
+        'service-user-capabilities',
+        serviceInstance?.id,
+        me?.id,
+        me?.selected_organization_id,
+      ],
       staleTime: ServiceUserCapabilitiesStaleTime,
     }
   );
+
   const userServiceCapabilities =
     data?.userServiceCapabilities?.userServiceCapabilities;
   const subscriptionId = data?.userServiceCapabilities?.subscription_id;


### PR DESCRIPTION
## Why it's flaky

`Should add subscription with capabilities` chains 5 full login/logout cycles plus DB setup, admin steps, form submits and a file upload, all in one `test()`. Playwright's default test timeout is 30s for the whole test (including `beforeEach`), not per action.

CI logs show a passing run at 29.6s — right on the edge. #3193/#3208 (merged the day before this issue was filed) swapped a free, SSR-loaded capability check for a client-side GraphQL query fired on every navigation into a service page. This test hits that page 4 times, and the added latency is enough to occasionally push it past 30s. When the test timeout fires, Playwright just reports whatever action was in flight, which is why the issue shows two different symptoms (menu not appearing vs dialog not stable) — same root cause, different action caught mid-flight depending on the run.

I also checked if this was actually a React Query caching bug rather than plain latency, since I found a real caching issue below. It's not: every login in this spec goes through `page.goto('/login')`, a hard navigation, between each user switch. That tears down the JS runtime and the QueryClient with it, so each user always starts with an empty cache here. Just latency stacking against the shared timeout.

## Fix

Bumped the default timeout in `playwright.config.ts` from 30s to 60s instead of `test.slow()` on this one test, so other heavy specs get the same headroom for free.

## Unrelated bug I found while poking at this: stale capability cache across users

Checked whether the new capability query was at least cached client-side to avoid paying for it on every navigation — it is (`use-service-capability.tsx`, 10mn staleTime, keyed on service_instance_id), so that's not the problem, and this test can't use or be hurt by it anyway given the hard reloads above.

But that's where I noticed logout/login in the real app are both client-side navigations (`router.push` + `router.refresh()`, no reload), so the QueryClient singleton survives a user switch in the same tab. Within the staleTime window, a second user logging into the same tab could get served the first user's cached capabilities — wrong Upload/Delete buttons shown.

Fixed with a `queryClient.clear()` in the logout handler once the mutation completes. One place, covers every user-scoped query now and later, instead of relying on every query key remembering to include user/org id. Org switching is unaffected, that already does a hard `window.location.href` reload.

## Validation

- `yarn lint` in `apps/e2e` passes
- `yarn lint` / `tsc --noEmit` in `apps/frontend` pass for the changed files

Fixes #3263