### PR TITLE
ci(dockerbuild): pass PR title/number safely via env instead of shell interpolation (#3263)

### DIFF
--- a/.github/workflows/dockerbuild-ci.yml
+++ b/.github/workflows/dockerbuild-ci.yml
@@ -218,17 +218,18 @@ jobs:
           cp ./apps/backend/tests/test-utils.ts ./apps/e2e/test-utils.ts
 
       - name: Launch docker compose
+        env:
+          IMAGE_TAGS: ${{ needs.build-images-tests.outputs.docker-tags }}
+          TEAMS_WEBHOOK_E2E: ${{ secrets.TEAMS_WEBHOOK_E2E }}
+          GITHUB_PR_TITLE: ${{ github.event.pull_request.title }}
+          GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          PLAYWRIGHT_SHARD: ${{ matrix.shard }}/8
         run: |
           mkdir -p ctrf
-          export IMAGE_TAGS="${{ needs.build-images-tests.outputs.docker-tags }}" \
-           TEAMS_WEBHOOK_E2E="${{ secrets.TEAMS_WEBHOOK_E2E }}" \
-           GITHUB_PR_TITLE="${{ github.event.pull_request.title }}" \
-           GITHUB_PR_NUMBER="${{ github.event.pull_request.number }}" \
-           GITHUB_RUN_ID="${{ github.run_id }}" \
-           PLAYWRIGHT_SHARD="${{ matrix.shard }}/8"
           docker compose -f ./xtm-hub-dev/docker-compose-ci.yml pull --include-deps e2e
           docker compose -f ./xtm-hub-dev/docker-compose-ci.yml run \
-           -e PLAYWRIGHT_SHARD \
+           -e IMAGE_TAGS -e TEAMS_WEBHOOK_E2E -e GITHUB_PR_TITLE -e GITHUB_PR_NUMBER -e GITHUB_RUN_ID -e PLAYWRIGHT_SHARD \
            e2e sh -lc "yarn test:e2e --shard=${PLAYWRIGHT_SHARD}" || TEST_EXIT_CODE=$?
           CONTAINER_ID=$(docker ps -a --filter "name=e2e-run" --format "{{.ID}}" | head -1)
           docker cp $CONTAINER_ID:/app/apps/e2e/ctrf/. ./ctrf/


### PR DESCRIPTION
## What

Fixes a fragility bug in the "Launch docker compose" step of `.github/workflows/dockerbuild-ci.yml`.

GitHub Actions substitutes `${{ github.event.pull_request.title }}` (and other `${{ }}` expressions) as raw text into the shell script *before* bash runs it. If the PR title contains a double quote (e.g. `fix: handle "edge case" (#123)`), the substituted `export` line becomes malformed:

```bash
export ... GITHUB_PR_TITLE="fix: handle "edge case" (#123)" ...
```

The embedded quotes close the string early, so bash re-parses the trailing tokens as separate bare words, and `export` fails with:

```
export: `case" (#123)"': not a valid identifier
```

This actually broke CI for a real PR whose title contained embedded double quotes.

## Fix

Move `IMAGE_TAGS`, `TEAMS_WEBHOOK_E2E`, `GITHUB_PR_TITLE`, `GITHUB_PR_NUMBER`, `GITHUB_RUN_ID` and `PLAYWRIGHT_SHARD` into the step's `env:` block instead of interpolating `${{ }}` directly into the `run:` script. GitHub Actions then sets these as real environment variables rather than doing textual substitution into the script body, so arbitrary characters (quotes, backticks, `$`, etc.) in the PR title can no longer break the shell parse. The downstream `docker compose run -e ...` invocation now passes all of these through by name (`-e VAR_NAME`), matching how `PLAYWRIGHT_SHARD` was already handled.

No other steps/jobs were touched — this is a scoped, pure CI workflow fix with no application code changes.

## Context

Related to #3263 (discovered while fixing that issue's flaky e2e test in #3268), but this is a separate, independent CI hardening fix.

## Validation

- `.github/workflows/dockerbuild-ci.yml` parses as well-formed YAML (verified with `js-yaml`).
- Rest of the "Launch docker compose" step logic (docker ps, container id capture, exit code handling) is unchanged.