### PR TITLE
feat(trial): stop creating auth0 audience for OpenCTI instance (#2638)

### DIFF
--- a/apps/backend/src/modules/deployment/deployment.domain.test.ts
+++ b/apps/backend/src/modules/deployment/deployment.domain.test.ts
@@ -1825,7 +1825,7 @@ describe('deploymentRequestDomain', () => {
     it.each`
       platformIdentifier            | shouldCreateAudience
       ${PlatformIdentifier.Openaev} | ${false}
-      ${PlatformIdentifier.Opencti} | ${true}
+      ${PlatformIdentifier.Opencti} | ${false}
       ${PlatformIdentifier.Xtmone}  | ${false}
     `(
       'should create an Auth0 audience for a $platformIdentifier instance: $shouldCreateAudience',

--- a/apps/backend/src/modules/deployment/deployment.domain.ts
+++ b/apps/backend/src/modules/deployment/deployment.domain.ts
@@ -407,7 +407,6 @@ export const DeploymentRequestDomain = {
     }
 
     const {
-      organization_name,
       requester_email,
       platform_id,
       user_requester_id,
@@ -415,17 +414,6 @@ export const DeploymentRequestDomain = {
     } = fullDeploymentRequest;
     if (!platform_id) {
       throw new Error(ErrorCode.InvalidPlatformId);
-    }
-
-    if (platformIdentifier === PlatformIdentifier.Opencti) {
-      try {
-        await auth0Client.createAudienceAPI(organization_name, platform_id);
-      } catch (error) {
-        logApp.warn('Unable to create audience', {
-          error,
-          deploymentRequestId: id,
-        });
-      }
     }
 
     const serviceGroup = await ServiceGroupDomain.loadServiceGroups({
@@ -525,10 +513,11 @@ export const DeploymentRequestDomain = {
 };
 
 /**
- * Bundles never create an Auth0 audience for themselves nor for their XtmOne
- * or OpenAEV children, unlike standalone trials which do create one for
- * OpenAEV (and Opencti). This tells callers whether it is worth attempting
- * to delete an audience for a given deployment request.
+ * Bundles never create an Auth0 audience for themselves nor for their XtmOne,
+ * OpenAEV or Opencti children. Standalone OpenAEV and Opencti trials no
+ * longer create one either, but older deployment requests may still have one
+ * left over. This tells callers whether it is worth attempting to delete an
+ * audience for a given deployment request.
  */
 export const shouldDeleteDeploymentRequestAudience = (
   deploymentRequest: Pick<


### PR DESCRIPTION
## Description

We changed strategy to manage user access in a trial instance: an Auth0 audience is no longer required for OpenCTI trials, mirroring the earlier change for OpenAEV (#2637).

## Changes

- `initialiseServiceGroup` no longer calls `auth0Client.createAudienceAPI` when provisioning an OpenCTI instance.
- Audience **deletion** on cancellation is unchanged — `shouldDeleteDeploymentRequestAudience` still returns `true` for OpenCTI trials, since older deployment requests may still have an audience left over to clean up.
- Updated `deployment.domain.test.ts` so the `initialiseServiceGroup` test table expects no audience creation for OpenCTI.

Closes #2638