### PR TITLE
fix(bundletrials): refresh trial status and platforms menu after bundle request (#3324)

### DIFF
--- a/apps/backend/src/modules/registration/registration.domain.test.ts
+++ b/apps/backend/src/modules/registration/registration.domain.test.ts
@@ -634,7 +634,7 @@ describe('registration domain', () => {
       expect(platforms).toHaveLength(1);
       expect(platforms[0]?.platform_id).toBe(platformId);
     });
-    it('should not return platforms with non-active trials when onlyActiveTrials is true', async () => {
+    it('should not return platforms with non-active trials when onlyActive is true', async () => {
       await DeploymentRequestDomain.insertDeploymentRequest({
         id: uuidv4() as DeploymentRequest['id'],
         service_instance_id: openCTIServiceInstanceId,
@@ -657,7 +657,7 @@ describe('registration domain', () => {
 
       expect(platforms).toHaveLength(0);
     });
-    it('should not return platforms with cancelled trials when onlyActiveTrials is true', async () => {
+    it('should not return platforms with cancelled trials when onlyActive is true', async () => {
       await DeploymentRequestDomain.insertDeploymentRequest({
         id: uuidv4() as DeploymentRequest['id'],
         service_instance_id: openCTIServiceInstanceId,
@@ -680,7 +680,7 @@ describe('registration domain', () => {
 
       expect(platforms).toHaveLength(0);
     });
-    it('should return platforms with active trials when onlyActiveTrials is true', async () => {
+    it('should return platforms with active trials when onlyActive is true', async () => {
       await DeploymentRequestDomain.insertDeploymentRequest({
         id: uuidv4() as DeploymentRequest['id'],
         service_instance_id: openCTIServiceInstanceId,
@@ -704,7 +704,7 @@ describe('registration domain', () => {
       expect(platforms).toHaveLength(1);
       expect(platforms[0]?.platform_id).toBe(platformId);
     });
-    it('should return platforms only active trials when onlyActiveTrials is true AND onlyTrial is true', async () => {
+    it('should return platforms only active trials when onlyActive is true AND onlyTrial is true', async () => {
       await DeploymentRequestDomain.insertDeploymentRequest({
         id: uuidv4() as DeploymentRequest['id'],
         service_instance_id: openCTIServiceInstanceId,

--- a/apps/backend/src/modules/registration/registration.domain.test.ts
+++ b/apps/backend/src/modules/registration/registration.domain.test.ts
@@ -657,6 +657,29 @@ describe('registration domain', () => {
 
       expect(platforms).toHaveLength(0);
     });
+    it('should not return platforms with cancelled trials when onlyActiveTrials is true', async () => {
+      await DeploymentRequestDomain.insertDeploymentRequest({
+        id: uuidv4() as DeploymentRequest['id'],
+        service_instance_id: openCTIServiceInstanceId,
+        platform_identifier: PlatformIdentifier.Opencti,
+        region: DeploymentRequestPlatformRegion.EuWest,
+        type: DeploymentRequestDeploymentType.Trial,
+        hub_status: DeploymentRequestHubStatus.Cancelled,
+        platform_token: uuidv4(),
+        organization_requester_id: TEST_ORGANIZATIONS.SECOND_ORGANIZATION.ID,
+        user_requester_id:
+          TEST_ORGANIZATIONS.SECOND_ORGANIZATION.USERS.REGISTERER.ID,
+        ordering: 1,
+        request_date: new Date(),
+      });
+
+      const platforms = await RegistrationDomain.loadRegisteredPlatforms({
+        platformIdentifier: PlatformIdentifier.Opencti,
+        onlyActive: true,
+      });
+
+      expect(platforms).toHaveLength(0);
+    });
     it('should return platforms with active trials when onlyActiveTrials is true', async () => {
       await DeploymentRequestDomain.insertDeploymentRequest({
         id: uuidv4() as DeploymentRequest['id'],

--- a/apps/frontend/src/components/menu/navigation/private/use-private-navigation.test.ts
+++ b/apps/frontend/src/components/menu/navigation/private/use-private-navigation.test.ts
@@ -529,7 +529,7 @@ describe('usePrivateNavigation', () => {
         {
           input: {
             identifier: null,
-            onlyActive: null,
+            onlyActive: true,
             onlyTrial: null,
             hasDeployedResources: null,
           },
@@ -540,7 +540,7 @@ describe('usePrivateNavigation', () => {
             {
               input: {
                 identifier: null,
-                onlyActive: null,
+                onlyActive: true,
                 onlyTrial: null,
                 hasDeployedResources: null,
               },

--- a/apps/frontend/src/components/menu/navigation/private/use-private-navigation.ts
+++ b/apps/frontend/src/components/menu/navigation/private/use-private-navigation.ts
@@ -49,7 +49,7 @@ import { useContext, useMemo } from 'react';
 const PRIVATE_NAVIGATION_REGISTERED_PLATFORMS_VARIABLES = {
   input: {
     identifier: null,
-    onlyActive: null,
+    onlyActive: true,
     onlyTrial: null,
     hasDeployedResources: null,
   },

--- a/apps/frontend/src/components/service/trial-instances/xtm-platform-trial/PrivateXtmPlatformTrialPanel.test.tsx
+++ b/apps/frontend/src/components/service/trial-instances/xtm-platform-trial/PrivateXtmPlatformTrialPanel.test.tsx
@@ -17,7 +17,7 @@ import { platformTrialKeys } from '@graphql/trial/trial.keys';
 import { QueryClient } from '@tanstack/react-query';
 import { screen } from '@testing-library/react';
 import { ReactNode } from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const graphqlMocks = vi.hoisted(() => ({
   useCreateDeploymentRequestMutation: vi.fn(),
@@ -166,7 +166,10 @@ const statusView = (
 });
 
 describe('PrivateXtmPlatformTrialPanel', () => {
+  let invalidateQueries: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
+    invalidateQueries = vi.spyOn(QueryClient.prototype, 'invalidateQueries');
     graphqlMocks.useCreateDeploymentRequestMutation.mockReset();
     graphqlMocks.mutate.mockReset();
     graphqlMocks.useCreateDeploymentRequestMutation.mockReturnValue({
@@ -176,12 +179,11 @@ describe('PrivateXtmPlatformTrialPanel', () => {
     queryMocks.invalidatePrivateNavigationQueries.mockReset();
   });
 
-  it('refreshes the bundle and the navigation queries after a successful request', () => {
-    const invalidateQueries = vi.spyOn(
-      QueryClient.prototype,
-      'invalidateQueries'
-    );
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
+  it('refreshes the bundle and the navigation queries after a successful request', () => {
     testRender(
       <PrivateXtmPlatformTrialPanel
         bundle={null}
@@ -212,8 +214,6 @@ describe('PrivateXtmPlatformTrialPanel', () => {
     expect(queryMocks.invalidatePrivateNavigationQueries).toHaveBeenCalledWith(
       expect.any(QueryClient)
     );
-
-    invalidateQueries.mockRestore();
   });
 
   it('renders nothing while the view is not resolved yet', () => {

--- a/apps/frontend/src/components/service/trial-instances/xtm-platform-trial/PrivateXtmPlatformTrialPanel.test.tsx
+++ b/apps/frontend/src/components/service/trial-instances/xtm-platform-trial/PrivateXtmPlatformTrialPanel.test.tsx
@@ -4,6 +4,7 @@ import {
   XtmPlatformTrialStatusPanelState,
 } from '@/components/service/trial-instances/xtm-platform-trial/xtm-platform-trial-panel.utils';
 import testRender from '@/utils/test/test-render';
+import { xtmPlatformBundleKeys } from '@graphql/deployment/deployment.keys';
 import {
   DeploymentRequestDeploymentType,
   DeploymentRequestHubStatus,
@@ -12,6 +13,8 @@ import {
   PlatformIdentifier,
   XtmPlatformBundleDetailsFragment,
 } from '@graphql/generated';
+import { platformTrialKeys } from '@graphql/trial/trial.keys';
+import { QueryClient } from '@tanstack/react-query';
 import { screen } from '@testing-library/react';
 import { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -20,6 +23,18 @@ const graphqlMocks = vi.hoisted(() => ({
   useCreateDeploymentRequestMutation: vi.fn(),
   mutate: vi.fn(),
 }));
+
+const queryMocks = vi.hoisted(() => ({
+  invalidatePrivateNavigationQueries: vi.fn(),
+}));
+
+vi.mock(
+  '@/components/menu/navigation/private/private-navigation-query-invalidation',
+  () => ({
+    invalidatePrivateNavigationQueries:
+      queryMocks.invalidatePrivateNavigationQueries,
+  })
+);
 
 vi.mock('@graphql/generated', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@graphql/generated')>();
@@ -158,6 +173,47 @@ describe('PrivateXtmPlatformTrialPanel', () => {
       mutate: graphqlMocks.mutate,
     });
     capturedHandleSubmit = undefined;
+    queryMocks.invalidatePrivateNavigationQueries.mockReset();
+  });
+
+  it('refreshes the bundle and the navigation queries after a successful request', () => {
+    const invalidateQueries = vi.spyOn(
+      QueryClient.prototype,
+      'invalidateQueries'
+    );
+
+    testRender(
+      <PrivateXtmPlatformTrialPanel
+        bundle={null}
+        view={formView(false)}
+        ongoingStandaloneTrials={[]}
+      />
+    );
+
+    expect(
+      queryMocks.invalidatePrivateNavigationQueries
+    ).not.toHaveBeenCalled();
+
+    const [, options] =
+      graphqlMocks.useCreateDeploymentRequestMutation.mock.calls[0];
+    options.onSuccess();
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: platformTrialKeys.platformTrialStatus({
+        organizationId: 'org-test-456',
+      }),
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: xtmPlatformBundleKeys.all(),
+    });
+    expect(
+      queryMocks.invalidatePrivateNavigationQueries
+    ).toHaveBeenCalledOnce();
+    expect(queryMocks.invalidatePrivateNavigationQueries).toHaveBeenCalledWith(
+      expect.any(QueryClient)
+    );
+
+    invalidateQueries.mockRestore();
   });
 
   it('renders nothing while the view is not resolved yet', () => {

--- a/apps/frontend/src/components/service/trial-instances/xtm-platform-trial/PrivateXtmPlatformTrialPanel.tsx
+++ b/apps/frontend/src/components/service/trial-instances/xtm-platform-trial/PrivateXtmPlatformTrialPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { PortalContext } from '@/components/me/AppPortalContext';
+import { invalidatePrivateNavigationQueries } from '@/components/menu/navigation/private/private-navigation-query-invalidation';
 import { ReachSalesButton } from '@/components/service/trial-instances/reach-sales/ReachSalesButton';
 import {
   XtmPlatformTrialForm,
@@ -19,6 +20,7 @@ import { BundleCancelSheet } from '@/components/xtm-platform-trial/BundleCancelS
 import { portalGraphqlClient } from '@/lib/graphql-client';
 import { Button } from '@filigran/ui';
 import { toast } from '@filigran/ui/clients';
+import { xtmPlatformBundleKeys } from '@graphql/deployment/deployment.keys';
 import {
   DeploymentRequestDeploymentType,
   DeploymentRequestSource,
@@ -56,6 +58,10 @@ export const PrivateXtmPlatformTrialPanel = ({
       queryClient.invalidateQueries({
         queryKey: platformTrialKeys.platformTrialStatus(variables),
       });
+      queryClient.invalidateQueries({
+        queryKey: xtmPlatformBundleKeys.all(),
+      });
+      invalidatePrivateNavigationQueries(queryClient);
       toast({
         title: t('Utils.Success'),
         description: t('Service.Trials.Form.FormRequested'),


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.


## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.
this pr 
-automatically switch to the display of ‘pending’ trial once we request a bundle instead of just showing the form
- if a standalone trial was cancelled (for example when we request a bundle),  we update the menu so it disappears from ‘my platforms’

https://github.com/user-attachments/assets/ba5285db-558a-4b68-a630-aa0a7a144dc5


## Related issues

- Related to #3324

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.