### PR TITLE
fix(frontend): prevent prefetch making loop (#3326)

### DIFF
--- a/apps/frontend/src/components/service/components/header/ServiceListHeaderButtons.tsx
+++ b/apps/frontend/src/components/service/components/header/ServiceListHeaderButtons.tsx
@@ -45,14 +45,15 @@ const ServiceListHeaderButtons = ({}) => {
   return (
     <div className="flex gap-s">
       {(hasCapaManageAccess || isAdminOrga || isBypass) && subscriptionId && (
-        <>
-          <Button variant="secondary">
-            <Link
-              href={`/${APP_PATH}/manage/service/${serviceInstance.id}/subscription/${subscriptionId}`}>
-              {t('Service.Capabilities.ManageAccessName')}
-            </Link>
-          </Button>
-        </>
+        <Button
+          variant="secondary"
+          asChild>
+          <Link
+            href={`/${APP_PATH}/manage/service/${serviceInstance.id}/subscription/${subscriptionId}`}
+            prefetch={false}>
+            {t('Service.Capabilities.ManageAccessName')}
+          </Link>
+        </Button>
       )}
       {userCanUpdate && (
         <>

--- a/apps/frontend/src/components/ui/shareable-resource/ShareableResourceCard.tsx
+++ b/apps/frontend/src/components/ui/shareable-resource/ShareableResourceCard.tsx
@@ -65,7 +65,8 @@ const ShareableResourceCard = ({
       <Link
         className="flex flex-col flex-1 min-h-0 overflow-hidden"
         onClick={handleClick}
-        href={detailUrl}>
+        href={detailUrl}
+        prefetch={false}>
         <ShareableResourceCardHeader
           document={document}
           shouldDisplayBothIcons={isConnector}


### PR DESCRIPTION
## Problem

Visiting a protected `/app/*` page while unauthenticated (e.g. via a Next.js prefetch/RSC request, which appends its own `_rsc=<hash>` cache-busting query param) 

Related #3326