### PR TITLE
fix(frontend): add missing ThreadConference CTA aria-label translation (#3328)

### DIFF
--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -2062,7 +2062,8 @@
     "Description": "The annual gathering of the global threat intelligence and cyber defense community - where intelligence, exposure management and action come together.",
     "Date": "October 15, 2026 | Paris",
     "ImageAlt": "Thread Conference Banner",
-    "Cta": "Learn more"
+    "Cta": "Learn more",
+    "AriaLabel": "Would you like to participate in the Thread Conference? Learn more here."
   },
   "UnexpectedErrorDialog": {
     "Description": "Please try logging in again. If the issue persists, contact us for assistance.",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -2062,7 +2062,8 @@
     "Description": "Le rendez-vous annuel de la communauté mondiale du renseignement sur les menaces et de la cyberdéfense, où se croisent renseignement, gestion des risques et action.",
     "Date": "15 octobre 2026 | Paris",
     "ImageAlt": "Bannière de la conférence Thread",
-    "Cta": "En savoir plus"
+    "Cta": "En savoir plus",
+    "AriaLabel": "Souhaitez-vous participer à la Thread Conference ? En savoir plus ici."
   },
   "UnexpectedErrorDialog": {
     "Description": "Veuillez essayer de vous connecter à nouveau. Si le problème persiste, contactez-nous pour obtenir de l'aide.",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -2062,7 +2062,8 @@
     "Description": "世界的な脅威インテリジェンスおよびサイバー防衛コミュニティによる年次集会――インテリジェンス、リスク管理、そして実践が一堂に会する場。",
     "Date": "2026年10月15日 | パリ",
     "ImageAlt": "Thread Conference バナー",
-    "Cta": "詳細はこちら"
+    "Cta": "詳細はこちら",
+    "AriaLabel": "Thread Conferenceに参加しませんか？詳細はこちらをご覧ください。"
   },
   "UnexpectedErrorDialog": {
     "Description": "再度ログインをお試しください。それでも問題が解決しない場合は、お問い合わせください。",

--- a/apps/frontend/src/components/homepage/ThreadConferenceBanner.test.tsx
+++ b/apps/frontend/src/components/homepage/ThreadConferenceBanner.test.tsx
@@ -25,7 +25,7 @@ describe('ThreadConferenceBanner', () => {
 
     // Then the supplied banner artwork links to the conference website
     const bannerLink = screen.getByRole('link', {
-      name: 'Cta',
+      name: 'ThreadConference.AriaLabel',
     });
     const threadLogo = screen.getByRole('img', {
       name: 'XTM Hub logo',

--- a/apps/frontend/src/components/homepage/ThreadConferenceBanner.tsx
+++ b/apps/frontend/src/components/homepage/ThreadConferenceBanner.tsx
@@ -11,7 +11,7 @@ const ThreadConferenceBanner = async () => {
       href={THREAD_CONFERENCE_URL}
       target="_blank"
       rel="noopener noreferrer"
-      aria-label={t('Cta')}
+      aria-label={t('ThreadConference.AriaLabel')}
       className="block z-10">
       <div className="overflow-hidden rounded-lg bg-elevation-background-layer-1 dark:bg-black">
         <div className="flex flex-col items-start gap-m sm:flex-row sm:items-stretch">


### PR DESCRIPTION
## Description

`ThreadConferenceBanner` referenced a non-existent `Cta` translation key for its `aria-label`, causing a `MISSING_MESSAGE` runtime error.

## Fix

- Use a dedicated `ThreadConference.AriaLabel` message key instead.
- Added translations for `en`, `fr`, and `ja`:
  - **en**: "Would you like to participate in the Thread Conference? Learn more here."
  - **fr**: "Souhaitez-vous participer à la Thread Conference ? En savoir plus ici."
  - **ja**: "Thread Conferenceに参加しませんか？詳細はこちらをご覧ください。"
- Updated the existing test to match the new accessible name.

## Validation

- `yarn workspace @xtm-hub/frontend vitest run src/components/homepage/ThreadConferenceBanner.test.tsx` — passes
- `yarn workspace @xtm-hub/frontend eslint` on changed files — no new issues

Related #3328