### PR TITLE
fix(connected-products): map xtmone_registration to the XTM One platform identifier (#3335)

### DIFF
--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -409,7 +409,8 @@
       "Details": "Details",
       "Documentation": "Documentation",
       "ConnectPlatform": "Connect {platformName}",
-      "Trial": "Trial"
+      "Trial": "Trial",
+      "EE": "EE"
     }
   },
   "HomePage": {

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -409,7 +409,8 @@
       "Details": "Détails",
       "Documentation": "Documentation",
       "ConnectPlatform": "Connecter {platformName}",
-      "Trial": "Essai"
+      "Trial": "Essai",
+      "EE": "EE"
     }
   },
   "HomePage": {

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -409,7 +409,8 @@
       "Details": "詳細",
       "Documentation": "ドキュメント",
       "ConnectPlatform": "{platformName} を接続",
-      "Trial": "トライアル"
+      "Trial": "トライアル",
+      "EE": "EE"
     }
   },
   "HomePage": {

--- a/apps/frontend/src/components/connected-products/ConnectProductButton.tsx
+++ b/apps/frontend/src/components/connected-products/ConnectProductButton.tsx
@@ -11,7 +11,7 @@ import { useTranslations } from 'next-intl';
 
 interface ConnectProductButtonProps {
   onCloseDropdown?: () => void;
-  variant?: 'default' | 'secondary';
+  variant?: 'default' | 'secondary' | 'tertiary';
 }
 
 export const ConnectProductButton = ({

--- a/apps/frontend/src/components/connected-products/ConnectedProductItem.test.tsx
+++ b/apps/frontend/src/components/connected-products/ConnectedProductItem.test.tsx
@@ -62,6 +62,37 @@ describe('ConnectedProductItem', () => {
     }
   );
 
+  it('shows the EE badge when the contract is EE', () => {
+    testRender(
+      <ConnectedProductItem
+        platform={buildPlatform({ contract: PlatformContract.Ee })}
+        t={t}
+      />
+    );
+
+    expect(screen.getByText('Header.ConnectedProducts.EE')).toBeInTheDocument();
+  });
+
+  it.each`
+    contract                  | description
+    ${PlatformContract.Ce}    | ${'CE'}
+    ${PlatformContract.Trial} | ${'trial'}
+  `(
+    'does not show the EE badge when the contract is $description',
+    ({ contract }) => {
+      testRender(
+        <ConnectedProductItem
+          platform={buildPlatform({ contract })}
+          t={t}
+        />
+      );
+
+      expect(
+        screen.queryByText('Header.ConnectedProducts.EE')
+      ).not.toBeInTheDocument();
+    }
+  );
+
   it.each`
     identifier                                         | description
     ${ServiceDefinitionIdentifier.OpenctiRegistration} | ${'OpenCTI'}

--- a/apps/frontend/src/components/connected-products/ConnectedProductItem.test.tsx
+++ b/apps/frontend/src/components/connected-products/ConnectedProductItem.test.tsx
@@ -62,6 +62,29 @@ describe('ConnectedProductItem', () => {
     }
   );
 
+  it.each`
+    identifier                                         | description
+    ${ServiceDefinitionIdentifier.OpenctiRegistration} | ${'OpenCTI'}
+    ${ServiceDefinitionIdentifier.OpenaevRegistration} | ${'OpenAEV'}
+    ${ServiceDefinitionIdentifier.XtmoneRegistration}  | ${'XTM One'}
+  `(
+    'renders the platform icon for a $description platform',
+    ({ identifier }) => {
+      const { container } = testRender(
+        <ConnectedProductItem
+          platform={buildPlatform({
+            identifier,
+            subscription: null,
+            url: '',
+          })}
+          t={t}
+        />
+      );
+
+      expect(container.querySelector('svg')).toBeInTheDocument();
+    }
+  );
+
   it('renders the details button when a service instance is linked', () => {
     testRender(
       <ConnectedProductItem

--- a/apps/frontend/src/components/connected-products/ConnectedProductItem.tsx
+++ b/apps/frontend/src/components/connected-products/ConnectedProductItem.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/components/registration/PlatformIdentifierMapping';
 import { UseTranslationsProps } from '@/i18n/config';
 import { APP_PATH } from '@/utils/path/constant';
-import { OpenInNewIcon, TextSnippetIcon } from '@filigran/icon';
+import { LinkIcon, TextSnippetIcon } from '@filigran/icon';
 import { Badge, Button } from '@filigran/ui';
 import { PlatformContract } from '@graphql/generated';
 import Link from 'next/link';
@@ -56,22 +56,22 @@ export const ConnectedProductItem = ({
       <div className="flex w-16 items-center justify-end gap-xs">
         {detailPath && (
           <Button
-            variant="secondary"
+            variant="tertiary"
             size="icon"
-            className="h-7 w-7"
+            className="h-7 w-7 text-text-default-primary"
             asChild>
             <Link
               href={detailPath}
               aria-label={t('Header.ConnectedProducts.Details')}>
-              <TextSnippetIcon className="h-4 w-4" />
+              <TextSnippetIcon className="h-4 w-4 shrink-0" />
             </Link>
           </Button>
         )}
         {platform.url && (
           <Button
-            variant="secondary"
+            variant="tertiary"
             size="icon"
-            className="h-7 w-7"
+            className="h-7 w-7 text-text-default-primary"
             asChild>
             <Link
               href={platform.url}
@@ -81,7 +81,7 @@ export const ConnectedProductItem = ({
                 title:
                   platform.title ?? platformMeta?.name ?? platform.identifier,
               })}>
-              <OpenInNewIcon className="h-4 w-4" />
+              <LinkIcon className="h-4 w-4 shrink-0" />
             </Link>
           </Button>
         )}

--- a/apps/frontend/src/components/connected-products/ConnectedProductItem.tsx
+++ b/apps/frontend/src/components/connected-products/ConnectedProductItem.tsx
@@ -46,6 +46,13 @@ export const ConnectedProductItem = ({
           {t('Header.ConnectedProducts.Trial')}
         </Badge>
       )}
+      {platform.contract === PlatformContract.Ee && (
+        <Badge className="border-none bg-filigran-tonic-primary content-body-compact-medium">
+          <span className="text-text-negative-primary">
+            {t('Header.ConnectedProducts.EE')}
+          </span>
+        </Badge>
+      )}
       <div className="flex w-16 items-center justify-end gap-xs">
         {detailPath && (
           <Button

--- a/apps/frontend/src/components/connected-products/ConnectedProductsDropdown.tsx
+++ b/apps/frontend/src/components/connected-products/ConnectedProductsDropdown.tsx
@@ -68,7 +68,7 @@ export const ConnectedProductsDropdown = () => {
         )}
         <div className="flex flex-col gap-s p-m">
           <ConnectProductButton
-            variant="secondary"
+            variant="tertiary"
             onCloseDropdown={() => setOpen(false)}
           />
         </div>

--- a/apps/frontend/src/components/registration/PlatformIdentifierMapping.tsx
+++ b/apps/frontend/src/components/registration/PlatformIdentifierMapping.tsx
@@ -92,6 +92,7 @@ export const ServiceDefinitionIdentifierToPlatformIdentifier: Partial<
 > = {
   [ServiceDefinitionIdentifier.OpenctiRegistration]: PlatformIdentifier.Opencti,
   [ServiceDefinitionIdentifier.OpenaevRegistration]: PlatformIdentifier.Openaev,
+  [ServiceDefinitionIdentifier.XtmoneRegistration]: PlatformIdentifier.Xtmone,
 };
 
 export const serviceInstanceTagByPlatformIdentifier: Record<


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.
BEFORE:
<img width="355" height="310" alt="image" src="https://github.com/user-attachments/assets/7b5f2f07-b52a-436c-903a-1976f5c6c6a4" />

AFTER:
<img width="366" height="288" alt="image" src="https://github.com/user-attachments/assets/20b50d0f-de6e-42c1-896a-febb884486b8" />

## Related issues

- Related to #3335

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.