### PR TITLE
fix(trials): fix redirects behavior (#3336)

### DIFF
--- a/apps/frontend/app/(application)/app/(user)/service/xtm-platform-trial/[serviceInstanceId]/manage-users/client-section.test.tsx
+++ b/apps/frontend/app/(application)/app/(user)/service/xtm-platform-trial/[serviceInstanceId]/manage-users/client-section.test.tsx
@@ -1,0 +1,88 @@
+import ClientSection from '@app/(application)/app/(user)/service/xtm-platform-trial/[serviceInstanceId]/manage-users/client-section';
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react')>()),
+  use: <T,>(value: T) => value,
+}));
+
+const manageTrialHeaderProps = vi.hoisted(() => vi.fn());
+vi.mock(
+  '@/components/service/trial-instances/xtm-platform-trial/manage-trial/ManageTrialHeader',
+  () => ({
+    ManageTrialHeader: (props: {
+      backHref?: string;
+      backLabelKey?: string;
+    }) => {
+      manageTrialHeaderProps(props);
+      return <div data-testid="manage-trial-header" />;
+    },
+  })
+);
+
+vi.mock(
+  '@/components/service/trial-instances/xtm-platform-trial/manage-trial/ManageTrialRoleDescriptions',
+  () => ({ ManageTrialRoleDescriptions: () => <div /> })
+);
+vi.mock(
+  '@/components/service/trial-instances/xtm-platform-trial/manage-trial/ManageTrialTable',
+  () => ({ ManageTrialTable: () => <div /> })
+);
+vi.mock('@/components/ui/BreadcrumbNav', () => ({
+  BreadcrumbNav: () => <nav />,
+}));
+
+vi.mock('@graphql/service-group/service-group.keys', () => ({
+  bundleProductsKeys: { list: () => ['bundleProducts'] },
+  bundleUserServiceGroupsKeys: { list: () => ['bundleUserServiceGroups'] },
+}));
+
+vi.mock('@graphql/generated', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@graphql/generated')>()),
+  useBundleUserServiceGroupsQuery: () => ({
+    data: { bundleUserServiceGroups: [] },
+  }),
+  useBundleProductsQuery: () => ({
+    data: { bundleProducts: [] },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+const renderClientSection = (fromDashboard: boolean) =>
+  render(
+    <ClientSection
+      params={
+        { serviceInstanceId: 'bundle-1' } as unknown as Promise<{
+          serviceInstanceId: string;
+        }>
+      }
+      fromDashboard={fromDashboard}
+    />
+  );
+
+describe('manage-users ClientSection', () => {
+  beforeEach(() => {
+    manageTrialHeaderProps.mockReset();
+  });
+
+  it('overrides the back link when opened from the admin dashboard', () => {
+    renderClientSection(true);
+
+    expect(manageTrialHeaderProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backHref: '/app/admin/manage-trials',
+        backLabelKey: 'Service.Bundle.ManageTrial.BackToDashboardButton',
+      })
+    );
+  });
+
+  it('keeps the default back link for the standard trial flow', () => {
+    renderClientSection(false);
+
+    const props = manageTrialHeaderProps.mock.calls[0][0];
+    expect(props).not.toHaveProperty('backHref');
+    expect(props).not.toHaveProperty('backLabelKey');
+  });
+});

--- a/apps/frontend/app/(application)/app/(user)/service/xtm-platform-trial/[serviceInstanceId]/manage-users/client-section.tsx
+++ b/apps/frontend/app/(application)/app/(user)/service/xtm-platform-trial/[serviceInstanceId]/manage-users/client-section.tsx
@@ -6,7 +6,7 @@ import { ManageTrialRoleDescriptions } from '@/components/service/trial-instance
 import { ManageTrialTable } from '@/components/service/trial-instances/xtm-platform-trial/manage-trial/ManageTrialTable';
 import { BreadcrumbNav } from '@/components/ui/BreadcrumbNav';
 import { portalGraphqlClient } from '@/lib/graphql-client';
-import { APP_PATH } from '@/utils/path/constant';
+import { ADMIN_MANAGE_TRIALS_PATH, APP_PATH } from '@/utils/path/constant';
 import { SelectionState } from '@filigran/ui';
 import {
   useBundleProductsQuery,
@@ -26,9 +26,12 @@ const emptySelection = (): SelectionState => ({
   excludedIds: new Set<string>(),
 });
 
-const ClientSection = ({
-  params,
-}: ServiceXtmPlatformBundleManageUsersPageProps) => {
+interface ClientSectionProps {
+  params: ServiceXtmPlatformBundleManageUsersPageProps['params'];
+  fromDashboard: boolean;
+}
+
+const ClientSection = ({ params, fromDashboard }: ClientSectionProps) => {
   const t = useTranslations();
   const { serviceInstanceId } = use(params);
   const decodedServiceInstanceId = decodeURIComponent(serviceInstanceId);
@@ -99,6 +102,10 @@ const ClientSection = ({
           products={products}
           selectedUsers={selectedUsers}
           onUsersRemoved={() => setSelection(emptySelection())}
+          {...(fromDashboard && {
+            backHref: ADMIN_MANAGE_TRIALS_PATH,
+            backLabelKey: 'Service.Bundle.ManageTrial.BackToDashboardButton',
+          })}
         />
         <ManageTrialRoleDescriptions products={products} />
         <ManageTrialTable

--- a/apps/frontend/app/(application)/app/(user)/service/xtm-platform-trial/[serviceInstanceId]/manage-users/page.test.tsx
+++ b/apps/frontend/app/(application)/app/(user)/service/xtm-platform-trial/[serviceInstanceId]/manage-users/page.test.tsx
@@ -1,0 +1,91 @@
+import { isFeatureEnabled } from '@/utils/settings.service';
+import Page from '@app/(application)/app/(user)/service/xtm-platform-trial/[serviceInstanceId]/manage-users/page';
+import { render, screen } from '@testing-library/react';
+import { notFound } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils/settings.service', () => ({
+  isFeatureEnabled: vi.fn(),
+}));
+
+vi.mock('@/components/AdminGuard', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="admin-guard">{children}</div>
+  ),
+}));
+
+const clientSectionProps = vi.hoisted(() => vi.fn());
+vi.mock(
+  '@app/(application)/app/(user)/service/xtm-platform-trial/[serviceInstanceId]/manage-users/client-section',
+  () => ({
+    default: (props: { fromDashboard: boolean }) => {
+      clientSectionProps(props);
+      return (
+        <div data-testid="client-section">{String(props.fromDashboard)}</div>
+      );
+    },
+  })
+);
+
+const renderPage = async (from?: string) => {
+  const element = await Page({
+    params: Promise.resolve({ serviceInstanceId: 'bundle-1' }),
+    searchParams: Promise.resolve(from ? { from } : {}),
+  });
+  render(element);
+};
+
+describe('manage-users page', () => {
+  beforeEach(() => {
+    vi.mocked(isFeatureEnabled).mockReset();
+    vi.mocked(notFound).mockClear();
+    clientSectionProps.mockReset();
+  });
+
+  it('calls notFound when the XtmPlatformTrial feature flag is disabled', async () => {
+    vi.mocked(isFeatureEnabled).mockResolvedValue(false);
+
+    await Page({
+      params: Promise.resolve({ serviceInstanceId: 'bundle-1' }),
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it('flags fromDashboard when opened from the admin dashboard', async () => {
+    vi.mocked(isFeatureEnabled).mockResolvedValue(true);
+
+    await renderPage('dashboard');
+
+    expect(screen.getByTestId('client-section')).toHaveTextContent('true');
+    expect(clientSectionProps).toHaveBeenCalledWith(
+      expect.objectContaining({ fromDashboard: true })
+    );
+  });
+
+  it('flags fromDashboard when the origin param is provided as an array', async () => {
+    vi.mocked(isFeatureEnabled).mockResolvedValue(true);
+
+    const element = await Page({
+      params: Promise.resolve({ serviceInstanceId: 'bundle-1' }),
+      searchParams: Promise.resolve({ from: ['dashboard', 'other'] }),
+    });
+    render(element);
+
+    expect(clientSectionProps).toHaveBeenCalledWith(
+      expect.objectContaining({ fromDashboard: true })
+    );
+  });
+
+  it('does not flag fromDashboard for the default trial flow', async () => {
+    vi.mocked(isFeatureEnabled).mockResolvedValue(true);
+
+    await renderPage();
+
+    expect(screen.getByTestId('client-section')).toHaveTextContent('false');
+    expect(clientSectionProps).toHaveBeenCalledWith(
+      expect.objectContaining({ fromDashboard: false })
+    );
+  });
+});

--- a/apps/frontend/app/(application)/app/(user)/service/xtm-platform-trial/[serviceInstanceId]/manage-users/page.test.tsx
+++ b/apps/frontend/app/(application)/app/(user)/service/xtm-platform-trial/[serviceInstanceId]/manage-users/page.test.tsx
@@ -38,19 +38,25 @@ const renderPage = async (from?: string) => {
 describe('manage-users page', () => {
   beforeEach(() => {
     vi.mocked(isFeatureEnabled).mockReset();
-    vi.mocked(notFound).mockClear();
+    vi.mocked(notFound).mockReset();
     clientSectionProps.mockReset();
   });
 
-  it('calls notFound when the XtmPlatformTrial feature flag is disabled', async () => {
+  it('blocks the page and calls notFound when the XtmPlatformTrial feature flag is disabled', async () => {
     vi.mocked(isFeatureEnabled).mockResolvedValue(false);
-
-    await Page({
-      params: Promise.resolve({ serviceInstanceId: 'bundle-1' }),
-      searchParams: Promise.resolve({}),
+    vi.mocked(notFound).mockImplementation(() => {
+      throw new Error('NEXT_NOT_FOUND');
     });
 
+    await expect(
+      Page({
+        params: Promise.resolve({ serviceInstanceId: 'bundle-1' }),
+        searchParams: Promise.resolve({}),
+      })
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+
     expect(notFound).toHaveBeenCalled();
+    expect(clientSectionProps).not.toHaveBeenCalled();
   });
 
   it('flags fromDashboard when opened from the admin dashboard', async () => {

--- a/apps/frontend/app/(application)/app/(user)/service/xtm-platform-trial/[serviceInstanceId]/manage-users/page.tsx
+++ b/apps/frontend/app/(application)/app/(user)/service/xtm-platform-trial/[serviceInstanceId]/manage-users/page.tsx
@@ -7,7 +7,7 @@ import ClientSection from './client-section';
 
 export interface ServiceXtmPlatformBundleManageUsersPageProps {
   params: Promise<{ serviceInstanceId: string }>;
-  searchParams: Promise<{ from?: string }>;
+  searchParams: Promise<{ from?: string | string[] }>;
 }
 
 const Page = async ({
@@ -22,7 +22,8 @@ const Page = async ({
   }
 
   const { from } = await searchParams;
-  const fromDashboard = from === MANAGE_USERS_ORIGIN_DASHBOARD;
+  const fromValue = Array.isArray(from) ? from[0] : from;
+  const fromDashboard = fromValue === MANAGE_USERS_ORIGIN_DASHBOARD;
 
   return (
     <GuardCapacityComponent

--- a/apps/frontend/app/(application)/app/(user)/service/xtm-platform-trial/[serviceInstanceId]/manage-users/page.tsx
+++ b/apps/frontend/app/(application)/app/(user)/service/xtm-platform-trial/[serviceInstanceId]/manage-users/page.tsx
@@ -1,4 +1,5 @@
 import GuardCapacityComponent from '@/components/AdminGuard';
+import { MANAGE_USERS_ORIGIN_DASHBOARD } from '@/utils/path/constant';
 import { isFeatureEnabled } from '@/utils/settings.service';
 import { FeatureFlag, OrganizationCapability } from '@graphql/generated';
 import { notFound } from 'next/navigation';
@@ -6,10 +7,12 @@ import ClientSection from './client-section';
 
 export interface ServiceXtmPlatformBundleManageUsersPageProps {
   params: Promise<{ serviceInstanceId: string }>;
+  searchParams: Promise<{ from?: string }>;
 }
 
 const Page = async ({
   params,
+  searchParams,
 }: ServiceXtmPlatformBundleManageUsersPageProps) => {
   const xtmPlatformTrialEnabled = await isFeatureEnabled(
     FeatureFlag.XtmPlatformTrial
@@ -17,6 +20,9 @@ const Page = async ({
   if (!xtmPlatformTrialEnabled) {
     notFound();
   }
+
+  const { from } = await searchParams;
+  const fromDashboard = from === MANAGE_USERS_ORIGIN_DASHBOARD;
 
   return (
     <GuardCapacityComponent
@@ -26,7 +32,10 @@ const Page = async ({
         OrganizationCapability.AdministrateOrganization,
         OrganizationCapability.ManagePlatformRegistration,
       ]}>
-      <ClientSection params={params} />
+      <ClientSection
+        params={params}
+        fromDashboard={fromDashboard}
+      />
     </GuardCapacityComponent>
   );
 };

--- a/apps/frontend/app/(application)/app/(user)/service/xtm-platform-trial/[serviceInstanceId]/manage-users/page.tsx
+++ b/apps/frontend/app/(application)/app/(user)/service/xtm-platform-trial/[serviceInstanceId]/manage-users/page.tsx
@@ -1,5 +1,8 @@
 import GuardCapacityComponent from '@/components/AdminGuard';
-import { MANAGE_USERS_ORIGIN_DASHBOARD } from '@/utils/path/constant';
+import {
+  MANAGE_USERS_ORIGIN_DASHBOARD,
+  MANAGE_USERS_ORIGIN_PARAM,
+} from '@/utils/path/constant';
 import { isFeatureEnabled } from '@/utils/settings.service';
 import { FeatureFlag, OrganizationCapability } from '@graphql/generated';
 import { notFound } from 'next/navigation';
@@ -7,7 +10,7 @@ import ClientSection from './client-section';
 
 export interface ServiceXtmPlatformBundleManageUsersPageProps {
   params: Promise<{ serviceInstanceId: string }>;
-  searchParams: Promise<{ from?: string | string[] }>;
+  searchParams: Promise<{ [MANAGE_USERS_ORIGIN_PARAM]?: string | string[] }>;
 }
 
 const Page = async ({
@@ -21,8 +24,8 @@ const Page = async ({
     notFound();
   }
 
-  const { from } = await searchParams;
-  const fromValue = Array.isArray(from) ? from[0] : from;
+  const fromParam = (await searchParams)[MANAGE_USERS_ORIGIN_PARAM];
+  const fromValue = Array.isArray(fromParam) ? fromParam[0] : fromParam;
   const fromDashboard = fromValue === MANAGE_USERS_ORIGIN_DASHBOARD;
 
   return (

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -83,7 +83,7 @@
       "StatusActive": "Connected",
       "StatusNotConnected": "Not connected",
       "AccessProduct": "Access {productName}",
-      "StatusUnavailable": "Status unavailable",
+      "StatusUnavailable": "Unavailable",
       "ProductName": "Product name",
       "Connection": "Connection {productName}",
       "EditName": "Edit name",

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -1947,6 +1947,7 @@
         "Eyebrow": "XTM Platform free trial",
         "Description": "Easily manage your team and collaborate throughout your XTM Platform trial. Invite team members, assign roles and permissions, and ensure everyone has the right level of access to the platform.",
         "BackButton": "Back to XTM Platform Trial",
+        "BackToDashboardButton": "Back to dashboard",
         "GroupAction": "Group action",
         "GroupActionDisabledTooltip": "You need to select users in the list to apply group action",
         "BulkDeleteTooltip": "You can delete selected users",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -1947,6 +1947,7 @@
         "Eyebrow": "Essai gratuit XTM Platform",
         "Description": "Gérez facilement votre équipe et collaborez tout au long de votre essai XTM Platform. Invitez des membres, attribuez des rôles et des permissions, et assurez à chacun le bon niveau d'accès à la plateforme.",
         "BackButton": "Retour à la plateforme d'essai XTM",
+        "BackToDashboardButton": "Retour au tableau de bord",
         "GroupAction": "Action groupée",
         "GroupActionDisabledTooltip": "Vous devez sélectionner des utilisateurs dans la liste pour appliquer une action groupée",
         "BulkDeleteTooltip": "Vous pouvez supprimer les utilisateurs sélectionnés",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -83,7 +83,7 @@
       "StatusActive": "Connecté",
       "StatusNotConnected": "Non connecté",
       "AccessProduct": "Accéder à {productName}",
-      "StatusUnavailable": "Statut indisponible",
+      "StatusUnavailable": "Indisponible",
       "ProductName": "Nom du produit",
       "Connection": "Connexion {productName}",
       "EditName": "Modifier le nom",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -83,7 +83,7 @@
       "StatusActive": "接続済み",
       "StatusNotConnected": "未接続",
       "AccessProduct": "{productName}にアクセス",
-      "StatusUnavailable": "ステータスを取得できません",
+      "StatusUnavailable": "利用不可",
       "ProductName": "製品名",
       "Connection": "{productName}接続",
       "EditName": "名前を編集",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -1947,6 +1947,7 @@
         "Eyebrow": "XTM Platform 無料トライアル",
         "Description": "XTM Platform のトライアル期間中、チームを簡単に管理し、共同作業を行いましょう。メンバーを招待し、役割と権限を割り当てて、全員がプラットフォームに適切なレベルでアクセスできるようにします。",
         "BackButton": "XTM トライアルプラットフォームに戻る",
+        "BackToDashboardButton": "ダッシュボードに戻る",
         "GroupAction": "グループアクション",
         "GroupActionDisabledTooltip": "グループアクションを適用するには、リストからユーザーを選択する必要があります",
         "BulkDeleteTooltip": "選択したユーザーを削除できます",

--- a/apps/frontend/src/components/service/trial-instances/xtm-platform-trial/manage-trial/ManageTrialHeader.test.tsx
+++ b/apps/frontend/src/components/service/trial-instances/xtm-platform-trial/manage-trial/ManageTrialHeader.test.tsx
@@ -55,6 +55,46 @@ describe('ManageTrialHeader', () => {
     toastMock.mockReset();
   });
 
+  it('links the back button to the XTM Platform Trial page by default', () => {
+    setupQueryMocks();
+
+    testRender(
+      <ManageTrialHeader
+        serviceInstanceId="bundle-1"
+        products={Object.values(PlatformIdentifier)}
+        selectedUsers={[]}
+        onUsersRemoved={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole('link', {
+        name: 'Service.Bundle.ManageTrial.BackButton',
+      })
+    ).toHaveAttribute('href', '/app/service/xtm-platform-trial');
+  });
+
+  it('uses the provided back link when overridden', () => {
+    setupQueryMocks();
+
+    testRender(
+      <ManageTrialHeader
+        serviceInstanceId="bundle-1"
+        products={Object.values(PlatformIdentifier)}
+        selectedUsers={[]}
+        onUsersRemoved={vi.fn()}
+        backHref="/app/admin/manage-trials"
+        backLabelKey="Service.Bundle.ManageTrial.BackToDashboardButton"
+      />
+    );
+
+    expect(
+      screen.getByRole('link', {
+        name: 'Service.Bundle.ManageTrial.BackToDashboardButton',
+      })
+    ).toHaveAttribute('href', '/app/admin/manage-trials');
+  });
+
   it('opens the add trial user dialog when the button is clicked', async () => {
     setupQueryMocks();
 

--- a/apps/frontend/src/components/service/trial-instances/xtm-platform-trial/manage-trial/ManageTrialHeader.tsx
+++ b/apps/frontend/src/components/service/trial-instances/xtm-platform-trial/manage-trial/ManageTrialHeader.tsx
@@ -2,6 +2,7 @@
 
 import { AlertDialogComponent } from '@/components/ui/AlertDialog';
 import { portalGraphqlClient } from '@/lib/graphql-client';
+import { XTM_PLATFORM_TRIAL_PATH } from '@/utils/path/constant';
 import { ArrowUpwardIcon, DeleteIcon } from '@filigran/icon';
 import {
   Button,
@@ -97,7 +98,7 @@ export const ManageTrialHeader = ({
           variant="outline"
           className="gap-s border-elevation-border-default-layer-0"
           asChild>
-          <Link href="/service/xtm-platform-trial">
+          <Link href={XTM_PLATFORM_TRIAL_PATH}>
             <ArrowUpwardIcon className="h-3 w-3 -rotate-90" />
             {t('Service.Bundle.ManageTrial.BackButton')}
           </Link>

--- a/apps/frontend/src/components/service/trial-instances/xtm-platform-trial/manage-trial/ManageTrialHeader.tsx
+++ b/apps/frontend/src/components/service/trial-instances/xtm-platform-trial/manage-trial/ManageTrialHeader.tsx
@@ -35,6 +35,8 @@ interface ManageTrialHeaderProps {
   products: PlatformIdentifier[];
   selectedUsers: ManageTrialHeaderUser[];
   onUsersRemoved: () => void;
+  backHref?: string;
+  backLabelKey?: string;
 }
 
 export const ManageTrialHeader = ({
@@ -42,6 +44,8 @@ export const ManageTrialHeader = ({
   products,
   selectedUsers,
   onUsersRemoved,
+  backHref = XTM_PLATFORM_TRIAL_PATH,
+  backLabelKey = 'Service.Bundle.ManageTrial.BackButton',
 }: ManageTrialHeaderProps) => {
   const t = useTranslations();
   const queryClient = useQueryClient();
@@ -98,9 +102,9 @@ export const ManageTrialHeader = ({
           variant="outline"
           className="gap-s border-elevation-border-default-layer-0"
           asChild>
-          <Link href={XTM_PLATFORM_TRIAL_PATH}>
+          <Link href={backHref}>
             <ArrowUpwardIcon className="h-3 w-3 -rotate-90" />
-            {t('Service.Bundle.ManageTrial.BackButton')}
+            {t(backLabelKey)}
           </Link>
         </Button>
         <div className="flex flex-wrap items-center gap-s">

--- a/apps/frontend/src/components/trials/tab/TrialsTab.tsx
+++ b/apps/frontend/src/components/trials/tab/TrialsTab.tsx
@@ -29,7 +29,7 @@ import { portalGraphqlClient } from '@/lib/graphql-client';
 import { DEBOUNCE_TIME } from '@/utils/constant';
 import { i18nKey } from '@/utils/datatable';
 import { daysUntil, useDateFormatter } from '@/utils/date';
-import { APP_PATH } from '@/utils/path/constant';
+import { xtmPlatformTrialManageUsersFromDashboardPath } from '@/utils/path/constant';
 import {
   ArrowShapeUpIcon,
   ArrowShapeUpStackIcon,
@@ -304,7 +304,9 @@ const TrialsRowActions = ({ request, type, scope }: TrialsRowActionsProps) => {
                   className="border m-1"
                   aria-label={t('Service.Trials.ManageUsers.Title')}>
                   <Link
-                    href={`/${APP_PATH}/service/xtm-platform-trial/${request.service_instance_id}/manage-users`}>
+                    href={xtmPlatformTrialManageUsersFromDashboardPath(
+                      request.service_instance_id
+                    )}>
                     <GroupIcon className="h-4 w-4" />
                   </Link>
                 </Button>

--- a/apps/frontend/src/components/xtm-platform-trial/BundleProductCard.test.tsx
+++ b/apps/frontend/src/components/xtm-platform-trial/BundleProductCard.test.tsx
@@ -165,7 +165,7 @@ describe('BundleProductCard', () => {
       .getByText('XtmPlatformTrial.Products.AccessProduct')
       .closest('a');
     expect(accessLink).not.toBeNull();
-    expect(accessLink).toHaveAttribute('href', 'https://xtmone.example.io');
+    expect(accessLink).toHaveAttribute('href', 'https://xtmone.example.io/');
   });
 
   it('falls back to deployment request url when registered platform url is empty', () => {
@@ -187,7 +187,7 @@ describe('BundleProductCard', () => {
       .getByText('XtmPlatformTrial.Products.AccessProduct')
       .closest('a');
     expect(accessLink).not.toBeNull();
-    expect(accessLink).toHaveAttribute('href', 'https://xtmone.example.io');
+    expect(accessLink).toHaveAttribute('href', 'https://xtmone.example.io/');
   });
 
   it('hides the edit-name button when the user cannot manage', () => {

--- a/apps/frontend/src/components/xtm-platform-trial/BundleProductCard.tsx
+++ b/apps/frontend/src/components/xtm-platform-trial/BundleProductCard.tsx
@@ -8,6 +8,7 @@ import { PlatformUpdateSheet } from '@/components/service/components/PlatformUpd
 import { XtmoneStatusState } from '@/components/xtm-platform-trial/useXtmoneIntegrationStatus';
 import { XtmoneConnectionStatus } from '@/components/xtm-platform-trial/XtmoneConnectionStatus';
 import { useDateFormatter } from '@/utils/date';
+import { toExternalHref } from '@/utils/external-url';
 import { EditIcon } from '@filigran/icon';
 import { Badge, Button, Card, CardContent, Separator } from '@filigran/ui';
 import { GradientButton } from '@filigran/ui/servers';
@@ -50,7 +51,8 @@ export const BundleProductCard = ({
   const hasAccess = (registeredPlatform?.myGroups?.length ?? 0) > 0;
   const accessUrl =
     registeredPlatform?.url?.trim() || product.url?.trim() || null;
-  const canAccess = isXtmone ? !!accessUrl : hasAccess && !!accessUrl;
+  const accessHref = toExternalHref(accessUrl);
+  const canAccess = isXtmone ? !!accessHref : hasAccess && !!accessHref;
   const roleLabel = (registeredPlatform?.myGroups ?? [])
     .map((role) => role.name)
     .join(', ');
@@ -161,9 +163,9 @@ export const BundleProductCard = ({
         )}
         <div className="flex justify-end mt-auto">
           {isXtmone ? (
-            canAccess && accessUrl ? (
+            canAccess && accessHref ? (
               <Link
-                href={accessUrl}
+                href={accessHref}
                 target="_blank"
                 rel="noopener noreferrer">
                 <GradientButton
@@ -180,9 +182,9 @@ export const BundleProductCard = ({
             <Button
               asChild={canAccess}
               disabled={!canAccess}>
-              {canAccess && accessUrl ? (
+              {canAccess && accessHref ? (
                 <Link
-                  href={accessUrl}
+                  href={accessHref}
                   target="_blank"
                   rel="noopener noreferrer">
                   {accessLabel}

--- a/apps/frontend/src/utils/external-url.test.ts
+++ b/apps/frontend/src/utils/external-url.test.ts
@@ -12,6 +12,7 @@ describe('toExternalHref', () => {
     ${'http://opencti.io'}        | ${'http://opencti.io/'}
     ${'  opencti.example.com  '}  | ${'https://opencti.example.com/'}
     ${'HTTPS://OpenCTI.io'}       | ${'https://opencti.io/'}
+    ${'localhost:3000'}           | ${'https://localhost:3000/'}
   `('normalises "$input" to "$expected"', ({ input, expected }) => {
     expect(toExternalHref(input)).toBe(expected);
   });
@@ -28,7 +29,6 @@ describe('toExternalHref', () => {
     ${'file:///etc/passwd'}      | ${'file scheme'}
     ${'vbscript:msgbox(1)'}      | ${'vbscript scheme'}
     ${'ftp://example.com'}       | ${'ftp scheme'}
-    ${'localhost:3000'}          | ${'ambiguous single-label host:port'}
   `('returns null for $reason', ({ input }) => {
     expect(toExternalHref(input)).toBeNull();
   });

--- a/apps/frontend/src/utils/external-url.test.ts
+++ b/apps/frontend/src/utils/external-url.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { toExternalHref } from './external-url';
+
+describe('toExternalHref', () => {
+  it.each`
+    input                         | expected
+    ${'opencti.example.com'}      | ${'https://opencti.example.com/'}
+    ${'opencti.example.com/path'} | ${'https://opencti.example.com/path'}
+    ${'opencti.example.com:8443'} | ${'https://opencti.example.com:8443/'}
+    ${'//opencti.example.com'}    | ${'https://opencti.example.com/'}
+    ${'https://opencti.io'}       | ${'https://opencti.io/'}
+    ${'http://opencti.io'}        | ${'http://opencti.io/'}
+    ${'  opencti.example.com  '}  | ${'https://opencti.example.com/'}
+    ${'HTTPS://OpenCTI.io'}       | ${'https://opencti.io/'}
+  `('normalises "$input" to "$expected"', ({ input, expected }) => {
+    expect(toExternalHref(input)).toBe(expected);
+  });
+
+  it.each`
+    input                        | reason
+    ${null}                      | ${'null'}
+    ${undefined}                 | ${'undefined'}
+    ${''}                        | ${'empty string'}
+    ${'   '}                     | ${'blank string'}
+    ${'javascript:alert(1)'}     | ${'javascript scheme'}
+    ${'java\nscript:alert(1)'}   | ${'newline-injected scheme'}
+    ${'data:text/html,<script>'} | ${'data scheme'}
+    ${'file:///etc/passwd'}      | ${'file scheme'}
+    ${'vbscript:msgbox(1)'}      | ${'vbscript scheme'}
+    ${'ftp://example.com'}       | ${'ftp scheme'}
+    ${'localhost:3000'}          | ${'ambiguous single-label host:port'}
+  `('returns null for $reason', ({ input }) => {
+    expect(toExternalHref(input)).toBeNull();
+  });
+});

--- a/apps/frontend/src/utils/external-url.ts
+++ b/apps/frontend/src/utils/external-url.ts
@@ -1,0 +1,22 @@
+const SAFE_PROTOCOLS = ['http:', 'https:'];
+
+export const toExternalHref = (
+  url: string | null | undefined
+): string | null => {
+  if (!url) return null;
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+
+  const hasScheme = /^[a-zA-Z][a-zA-Z\d+-]*:/.test(trimmed);
+  const candidate = hasScheme ? trimmed : `https://${trimmed}`;
+
+  try {
+    const parsed = new URL(candidate);
+    if (!SAFE_PROTOCOLS.includes(parsed.protocol)) {
+      return null;
+    }
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+};

--- a/apps/frontend/src/utils/external-url.ts
+++ b/apps/frontend/src/utils/external-url.ts
@@ -8,7 +8,11 @@ export const toExternalHref = (
   if (!trimmed) return null;
 
   const hasScheme = /^[a-zA-Z][a-zA-Z\d+-]*:/.test(trimmed);
-  const candidate = hasScheme ? trimmed : `https://${trimmed}`;
+  const candidate = hasScheme
+    ? trimmed
+    : trimmed.startsWith('//')
+      ? `https:${trimmed}`
+      : `https://${trimmed}`;
 
   try {
     const parsed = new URL(candidate);

--- a/apps/frontend/src/utils/external-url.ts
+++ b/apps/frontend/src/utils/external-url.ts
@@ -7,7 +7,7 @@ export const toExternalHref = (
   const trimmed = url.trim();
   if (!trimmed) return null;
 
-  const hasScheme = /^[a-zA-Z][a-zA-Z\d+-]*:/.test(trimmed);
+  const hasScheme = /^[a-zA-Z][a-zA-Z\d+-]*:(?!\d)/.test(trimmed);
   const candidate = hasScheme
     ? trimmed
     : trimmed.startsWith('//')

--- a/apps/frontend/src/utils/path/constant.test.ts
+++ b/apps/frontend/src/utils/path/constant.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   ADMIN_MANAGE_TRIALS_PATH,
-  MANAGE_USERS_ORIGIN_DASHBOARD,
-  MANAGE_USERS_ORIGIN_PARAM,
   xtmPlatformTrialManageUsersFromDashboardPath,
-  xtmPlatformTrialManageUsersPath,
 } from './constant';
 
 describe('path constants', () => {
@@ -15,9 +12,6 @@ describe('path constants', () => {
   it('appends the dashboard origin query param to the manage-users path', () => {
     const path = xtmPlatformTrialManageUsersFromDashboardPath('bundle-1');
 
-    expect(path).toBe(
-      `${xtmPlatformTrialManageUsersPath('bundle-1')}?${MANAGE_USERS_ORIGIN_PARAM}=${MANAGE_USERS_ORIGIN_DASHBOARD}`
-    );
     expect(path).toBe(
       '/app/service/xtm-platform-trial/bundle-1/manage-users?from=dashboard'
     );

--- a/apps/frontend/src/utils/path/constant.test.ts
+++ b/apps/frontend/src/utils/path/constant.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ADMIN_MANAGE_TRIALS_PATH,
+  MANAGE_USERS_ORIGIN_DASHBOARD,
+  MANAGE_USERS_ORIGIN_PARAM,
+  xtmPlatformTrialManageUsersFromDashboardPath,
+  xtmPlatformTrialManageUsersPath,
+} from './constant';
+
+describe('path constants', () => {
+  it('builds the admin manage-trials path under the app prefix', () => {
+    expect(ADMIN_MANAGE_TRIALS_PATH).toBe('/app/admin/manage-trials');
+  });
+
+  it('appends the dashboard origin query param to the manage-users path', () => {
+    const path = xtmPlatformTrialManageUsersFromDashboardPath('bundle-1');
+
+    expect(path).toBe(
+      `${xtmPlatformTrialManageUsersPath('bundle-1')}?${MANAGE_USERS_ORIGIN_PARAM}=${MANAGE_USERS_ORIGIN_DASHBOARD}`
+    );
+    expect(path).toBe(
+      '/app/service/xtm-platform-trial/bundle-1/manage-users?from=dashboard'
+    );
+  });
+});

--- a/apps/frontend/src/utils/path/constant.ts
+++ b/apps/frontend/src/utils/path/constant.ts
@@ -12,4 +12,14 @@ export const xtmPlatformTrialBundlePath = (serviceInstanceId: string) =>
 export const xtmPlatformTrialManageUsersPath = (serviceInstanceId: string) =>
   `${xtmPlatformTrialBundlePath(serviceInstanceId)}/manage-users`;
 
+export const MANAGE_USERS_ORIGIN_PARAM = 'from';
+export const MANAGE_USERS_ORIGIN_DASHBOARD = 'dashboard';
+
+export const xtmPlatformTrialManageUsersFromDashboardPath = (
+  serviceInstanceId: string
+) =>
+  `${xtmPlatformTrialManageUsersPath(serviceInstanceId)}?${MANAGE_USERS_ORIGIN_PARAM}=${MANAGE_USERS_ORIGIN_DASHBOARD}`;
+
 export const XTM_PLATFORM_TRIAL_GUIDE_PATH = `/${APP_PATH}/service/xtm-platform-trial-guide`;
+
+export const ADMIN_MANAGE_TRIALS_PATH = `/${APP_PATH}/admin/manage-trials`;


### PR DESCRIPTION
# Context

- Back link missing `/app` prefix, `Back to XTM Platform Trial` pointed to `service/xtm-platform-trial` instead of `app/service/xtm-platform-trial`, landing on a broken route
- `Access` link resolving internally: scheme-less platform URLs (e.g. `opencti.example.com`) were treated as relative paths and redirected to `localhost:3002/app/service/...` Now normalized to external `https://` URLs
- Confusing back button from admin dashboard: opening manage-trials from the dashboard showed `Back to XTM Platform Trial`, it now shows `Back to dashboard`

## How to test

- Test that `Back to XTM Platform Trial` button redirects properly
https://github.com/user-attachments/assets/6a659428-1b84-4cb2-835e-7c712cfa827d

- Test that the `Back to ...` label adapts to where the page was reached
https://github.com/user-attachments/assets/4a8da7d2-2cf8-443e-ac8f-621ed3f860fe

## Related issues

- Related to #3336

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.