### PR TITLE
chore(deps): bump e2e docker image to playwright v1.63.0-noble (#3364)

### DIFF
--- a/apps/e2e/Dockerfile
+++ b/apps/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.62.0-noble
+FROM mcr.microsoft.com/playwright:v1.63.0-noble
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description

PR #3347 bumped `@playwright/test` in `apps/e2e/package.json` to `1.63.0`, but `apps/e2e/Dockerfile` still pinned the base image to `mcr.microsoft.com/playwright:v1.62.0-noble`. This mismatch between the npm package and the Docker base image can cause version-skew issues in CI e2e runs.

## Change

- Bump `apps/e2e/Dockerfile` base image to `mcr.microsoft.com/playwright:v1.63.0-noble` to match the `@playwright/test` version.

Verified the `v1.63.0-noble` tag exists in the `mcr.microsoft.com/playwright` registry.