### PR TITLE
refactor(frontend): mutualize roadmap and voting cards into DetailCard and updated styling (spaces, line clamp) (#3360)

### DIFF
--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -185,6 +185,14 @@
   "DisableUserDialog": {
     "TextDisableThisUser": "Are you sure you want to disable this user {email} ?"
   },
+  "EpicForm": {
+    "Error": {
+      "Title": "Title is required",
+      "ShortDescription": "Short description is required",
+      "ShortDescriptionMax": "Short description must be 215 characters or fewer",
+      "Description": "Description is required"
+    }
+  },
   "Epic": {
     "XTMRoadmap": "XTM Platform Roadmap",
     "AllProducts": "All products",
@@ -2327,6 +2335,7 @@
       "Error": {
         "Title": "Title is required",
         "ShortDescription": "Short description is required",
+        "ShortDescriptionMax": "Short description must be 215 characters or fewer",
         "Description": "Description is required",
         "Position": "Position must be a positive number"
       },

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -185,6 +185,14 @@
   "DisableUserDialog": {
     "TextDisableThisUser": "Êtes-vous sûr de vouloir désactiver cet utilisateur {email} ? ?"
   },
+  "EpicForm": {
+    "Error": {
+      "Title": "Le titre est obligatoire",
+      "ShortDescription": "La description courte est obligatoire",
+      "ShortDescriptionMax": "La description courte ne doit pas dépasser 215 caractères",
+      "Description": "La description est obligatoire"
+    }
+  },
   "Epic": {
     "XTMRoadmap": "Roadmap Platform XTM",
     "AllProducts": "Tous les produits",
@@ -2327,6 +2335,7 @@
       "Error": {
         "Title": "Le titre est obligatoire",
         "ShortDescription": "La description courte est obligatoire",
+        "ShortDescriptionMax": "La description courte ne doit pas dépasser 215 caractères",
         "Description": "La description est obligatoire",
         "Position": "La position doit être un nombre positif"
       },

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -185,6 +185,14 @@
   "DisableUserDialog": {
     "TextDisableThisUser": "本当にこのユーザー {email} を無効にしますか？"
   },
+  "EpicForm": {
+    "Error": {
+      "Title": "タイトルは必須です",
+      "ShortDescription": "概要は必須です",
+      "ShortDescriptionMax": "概要は215文字以内で入力してください",
+      "Description": "説明は必須です"
+    }
+  },
   "Epic": {
     "XTMRoadmap": "XTMスイートロードマップ",
     "AllProducts": "すべての製品",
@@ -2327,6 +2335,7 @@
       "Error": {
         "Title": "タイトルは必須です",
         "ShortDescription": "概要は必須です",
+        "ShortDescriptionMax": "概要は215文字以内で入力してください",
         "Description": "説明は必須です",
         "Position": "表示順は0以上の数値で入力してください"
       },

--- a/apps/frontend/src/components/admin/voting-round/VotableFeatureForm.tsx
+++ b/apps/frontend/src/components/admin/voting-round/VotableFeatureForm.tsx
@@ -23,6 +23,7 @@ import {
 import { FiligranProduct } from '@graphql/generated';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useTranslations } from 'next-intl';
+import { useMemo } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -43,23 +44,29 @@ export interface VotableFeatureFormModel {
   active: boolean;
 }
 
-export const votableFeatureFormSchema = z.object({
-  title: z.string().min(2, { error: 'VotingRound.Feature.Error.Title' }),
-  short_description: z
-    .string()
-    .min(2, { error: 'VotingRound.Feature.Error.ShortDescription' }),
-  description: z
-    .string()
-    .min(2, { error: 'VotingRound.Feature.Error.Description' }),
-  product: z.enum(productValues),
-  use_case_ids: z.array(z.string()),
-  illustration_document: z.custom<FileList>().optional(),
-  remove_illustration: z.boolean(),
-  position: z.string().regex(/^\d+$/, {
-    error: 'VotingRound.Feature.Error.Position',
-  }),
-  active: z.boolean(),
-});
+const buildVotableFeatureFormSchema = (t: (key: string) => string) =>
+  z.object({
+    title: z.string().min(2, { error: t('VotingRound.Feature.Error.Title') }),
+    short_description: z
+      .string()
+      .min(2, { error: t('VotingRound.Feature.Error.ShortDescription') })
+      .max(215, { error: t('VotingRound.Feature.Error.ShortDescriptionMax') }),
+    description: z
+      .string()
+      .min(2, { error: t('VotingRound.Feature.Error.Description') }),
+    product: z.enum(productValues),
+    use_case_ids: z.array(z.string()),
+    illustration_document: z.custom<FileList>().optional(),
+    remove_illustration: z.boolean(),
+    position: z.string().regex(/^\d+$/, {
+      error: t('VotingRound.Feature.Error.Position'),
+    }),
+    active: z.boolean(),
+  });
+
+export const votableFeatureFormSchema = buildVotableFeatureFormSchema(
+  (key) => key
+);
 
 export type VotableFeatureFormValues = z.infer<typeof votableFeatureFormSchema>;
 
@@ -77,8 +84,9 @@ const VotableFeatureForm = ({
   handleSubmit: (values: VotableFeatureFormValues) => void;
 }) => {
   const t = useTranslations();
+  const formSchema = useMemo(() => buildVotableFeatureFormSchema(t), [t]);
   const form = useForm<VotableFeatureFormValues>({
-    resolver: zodResolver(votableFeatureFormSchema),
+    resolver: zodResolver(formSchema),
     defaultValues: {
       title: feature?.title ?? '',
       short_description: feature?.short_description ?? '',

--- a/apps/frontend/src/components/epic/EpicForm.tsx
+++ b/apps/frontend/src/components/epic/EpicForm.tsx
@@ -27,7 +27,7 @@ import {
   Timeline,
 } from '@graphql/generated';
 import { useTranslations } from 'next-intl';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { ControllerRenderProps, FieldValues } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -45,17 +45,23 @@ export const descriptionValue =
   "'If EPIC is aimed at a specific persona, worth mentioning it here.\n";
 export const FILIGRAN_PRODUCTS_VALUES = Object.values(FiligranProduct);
 export const TIMELINE_VALUES = Object.values(Timeline);
-export const epicFormSchema = z.object({
-  product: z.enum(FILIGRAN_PRODUCTS_VALUES),
-  edition_type: z.enum(EditionType),
-  title: z.string().min(2, 'EpicForm.Error.Title').max(160),
-  short_description: z.string().min(1, 'Required').max(215),
-  description: z.string().min(1, 'Required'),
-  timeline: z.enum(TIMELINE_VALUES),
-  active: z.boolean().optional(),
-  is_integration: z.boolean().optional(),
-  illustration_document: z.custom<FileList>().optional(),
-});
+const buildEpicFormSchema = (t: (key: string) => string) =>
+  z.object({
+    product: z.enum(FILIGRAN_PRODUCTS_VALUES),
+    edition_type: z.enum(EditionType),
+    title: z.string().min(2, t('EpicForm.Error.Title')).max(160),
+    short_description: z
+      .string()
+      .min(1, t('EpicForm.Error.ShortDescription'))
+      .max(215, t('EpicForm.Error.ShortDescriptionMax')),
+    description: z.string().min(1, t('EpicForm.Error.Description')),
+    timeline: z.enum(TIMELINE_VALUES),
+    active: z.boolean().optional(),
+    is_integration: z.boolean().optional(),
+    illustration_document: z.custom<FileList>().optional(),
+  });
+
+export const epicFormSchema = buildEpicFormSchema((key) => key);
 
 const EpicForm = ({
   epic,
@@ -65,6 +71,7 @@ const EpicForm = ({
   handleSubmit: (values: z.infer<typeof epicFormSchema>) => void;
 }) => {
   const t = useTranslations();
+  const formSchema = useMemo(() => buildEpicFormSchema(t), [t]);
 
   const [isIntegration, setIsIntegration] = useState(
     epic?.epic_type === EpicType.Integration
@@ -76,7 +83,7 @@ const EpicForm = ({
       onValuesChange={(values) => {
         setIsIntegration(values.is_integration ?? false);
       }}
-      formSchema={epicFormSchema}
+      formSchema={formSchema}
       values={{
         title: epic?.title ?? '',
         short_description: epic?.short_description ?? '',

--- a/apps/frontend/src/components/epic/epic-item/EpicItem.tsx
+++ b/apps/frontend/src/components/epic/epic-item/EpicItem.tsx
@@ -1,10 +1,9 @@
 'use client';
 import { EpicItemCard } from '@/components/epic/epic-item/EpicItemCard';
 import { EpicItemDetailed } from '@/components/epic/epic-item/EpicItemDetailed';
+import { useDetailParam } from '@/hooks/use-detail-param';
 import { Dialog, DialogContent } from '@filigran/ui';
 import { epic_fragment$data } from '@generated/epic_fragment.graphql';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useCallback } from 'react';
 
 interface EpicItemProps {
   epic: epic_fragment$data;
@@ -19,29 +18,10 @@ export const EpicItem = ({
   userCanUpdate,
   userCanDelete,
 }: EpicItemProps) => {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-
-  const isOpen = searchParams.get('epicId') === epic.id;
-
-  const handleClose = useCallback(
-    (open: boolean) => {
-      if (!open) {
-        const params = new URLSearchParams(searchParams.toString());
-        params.delete('epicId');
-
-        const queryString = params.toString();
-        const targetUrl = queryString ? `${pathname}?${queryString}` : pathname;
-
-        router.replace(targetUrl, { scroll: false });
-      }
-    },
-    [router, pathname, searchParams]
-  );
+  const { isOpen, close } = useDetailParam('epicId', epic.id);
 
   return (
-    <li className="group overflow-hidden flex flex-col relative rounded hover:cursor-pointer bg-elevation-background-layer-1 h-[183px]">
+    <li className="h-full">
       <EpicItemCard
         epic={epic}
         serviceInstanceId={serviceInstanceId}
@@ -50,7 +30,7 @@ export const EpicItem = ({
       />
       <Dialog
         open={isOpen}
-        onOpenChange={handleClose}>
+        onOpenChange={(open) => !open && close()}>
         <DialogContent className="p-0 w-full max-w-5xl h-[80vh] max-h-[90vh] flex flex-col overflow-hidden">
           <EpicItemDetailed
             epic={epic}

--- a/apps/frontend/src/components/epic/epic-item/EpicItemCard.tsx
+++ b/apps/frontend/src/components/epic/epic-item/EpicItemCard.tsx
@@ -1,9 +1,9 @@
 import { EpicAdminMenu } from '@/components/epic/epic-item/EpicAdminMenu';
 import { EpicItemFooter } from '@/components/epic/epic-item/EpicItemFooter';
+import { DetailCard } from '@/components/ui/DetailCard';
+import { useDetailParam } from '@/hooks/use-detail-param';
 import { Separator } from '@filigran/ui/clients';
 import { epic_fragment$data } from '@generated/epic_fragment.graphql';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { MouseEvent, useCallback } from 'react';
 
 interface EpicItemCardProps {
   epic: epic_fragment$data;
@@ -18,47 +18,17 @@ export const EpicItemCard = ({
   userCanDelete,
   userCanUpdate,
 }: EpicItemCardProps) => {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-
-  const handleOpenDetail = useCallback(
-    (event: MouseEvent<HTMLDivElement>) => {
-      const { currentTarget, target } = event;
-      if (!(target instanceof Node) || !currentTarget.contains(target)) {
-        return;
-      }
-
-      if (
-        target instanceof HTMLElement &&
-        target.closest('[data-no-open-detail]')
-      ) {
-        return;
-      }
-
-      const params = new URLSearchParams(searchParams.toString());
-      params.set('epicId', epic.id);
-      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
-    },
-    [router, pathname, searchParams, epic.id]
-  );
+  const { open: openDetail } = useDetailParam('epicId', epic.id);
 
   return (
-    <>
-      <div
-        onClick={handleOpenDetail}
-        className="flex flex-col flex-1 bg-elevation-background-layer-1 text-ellipsis overflow-hidden p-m group-hover:bg-hover h-full w-full">
-        <h2 className="text-base font-semibold pr-xxl line-clamp-2">
-          {epic.title}
-        </h2>
-        <div className="mt-auto line-clamp-3">
-          <p className="h-full text-muted-foreground text-sm">
-            {epic.short_description}
-          </p>
-        </div>
-        <div className="mt-auto">
+    <DetailCard
+      onOpenDetail={openDetail}
+      title={epic.title}
+      description={epic.short_description}
+      footer={
+        <>
           <Separator />
-          <div className="mt-m flex flex-row ">
+          <div className="mt-m flex flex-row">
             <EpicItemFooter
               epic={epic}
               serviceInstanceId={serviceInstanceId}
@@ -69,8 +39,8 @@ export const EpicItemCard = ({
               userCanUpdate={userCanUpdate}
             />
           </div>
-        </div>
-      </div>
-    </>
+        </>
+      }
+    />
   );
 };

--- a/apps/frontend/src/components/feature-voting/FeatureVoteCard.tsx
+++ b/apps/frontend/src/components/feature-voting/FeatureVoteCard.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { FeatureVoteButton } from '@/components/feature-voting/FeatureVoteButton';
+import { DetailCard } from '@/components/ui/DetailCard';
+import { useDetailParam } from '@/hooks/use-detail-param';
 import { Badge } from '@filigran/ui/servers';
 import { VotableFeaturePublicFragment } from '@graphql/generated';
 import Image from 'next/image';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { MouseEvent, useCallback } from 'react';
 
 const BADGE_CLASS =
   'border-0 content-body-compact-medium bg-feedback-info-secondary-transparency';
@@ -21,66 +21,27 @@ export const FeatureVoteCard = ({
   serviceInstanceId,
   isAuthenticated,
 }: FeatureVoteCardProps) => {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-
-  const openDetail = useCallback(() => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('featureId', feature.id);
-    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
-  }, [router, pathname, searchParams, feature.id]);
-
-  // Clicking anywhere on the card is a mouse convenience only. Keyboard users
-  // reach the detail through the title, so the card stays a plain container
-  // rather than a widget wrapping other widgets.
-  const handleCardClick = useCallback(
-    (event: MouseEvent<HTMLDivElement>) => {
-      const { currentTarget, target } = event;
-      if (!(target instanceof Node) || !currentTarget.contains(target)) {
-        return;
-      }
-
-      if (
-        target instanceof HTMLElement &&
-        target.closest('[data-no-open-detail]')
-      ) {
-        return;
-      }
-
-      openDetail();
-    },
-    [openDetail]
-  );
+  const { open: openDetail } = useDetailParam('featureId', feature.id);
 
   return (
-    <div
-      onClick={handleCardClick}
-      className="flex h-full cursor-pointer flex-col overflow-hidden rounded bg-elevation-background-layer-1 hover:bg-hover">
-      {feature.illustration_document_id && (
-        <div className="relative h-32 w-full shrink-0">
-          <Image
-            src={`/document/images/${serviceInstanceId}/${feature.illustration_document_id}`}
-            alt={feature.title}
-            fill
-            className="object-cover"
-          />
-        </div>
-      )}
-      <div className="flex flex-1 flex-col gap-s p-m">
-        <h3 className="text-base font-semibold leading-tight line-clamp-2">
-          <button
-            type="button"
-            onClick={openDetail}
-            data-no-open-detail
-            className="focus-visible:ring-primary text-left underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2">
-            {feature.title}
-          </button>
-        </h3>
-        <p className="text-muted-foreground text-sm line-clamp-3">
-          {feature.short_description}
-        </p>
-        {feature.use_cases.length > 0 && (
+    <DetailCard
+      onOpenDetail={openDetail}
+      title={feature.title}
+      description={feature.short_description}
+      media={
+        feature.illustration_document_id && (
+          <div className="relative h-32 w-full shrink-0">
+            <Image
+              src={`/document/images/${serviceInstanceId}/${feature.illustration_document_id}`}
+              alt={feature.title}
+              fill
+              className="object-cover"
+            />
+          </div>
+        )
+      }
+      extra={
+        feature.use_cases.length > 0 && (
           <div className="flex flex-wrap items-center gap-s">
             {feature.use_cases.map((useCase) => (
               <Badge
@@ -90,11 +51,10 @@ export const FeatureVoteCard = ({
               </Badge>
             ))}
           </div>
-        )}
-        {/* Voting must not open the detail dialog. */}
-        <div
-          className="mt-auto pt-s"
-          data-no-open-detail>
+        )
+      }
+      footer={
+        <div data-no-open-detail>
           <FeatureVoteButton
             featureId={feature.id}
             hasMyVote={feature.has_my_vote}
@@ -102,7 +62,7 @@ export const FeatureVoteCard = ({
             className="w-full"
           />
         </div>
-      </div>
-    </div>
+      }
+    />
   );
 };

--- a/apps/frontend/src/components/feature-voting/FeatureVotingItem.tsx
+++ b/apps/frontend/src/components/feature-voting/FeatureVotingItem.tsx
@@ -2,10 +2,9 @@
 
 import { FeatureVoteCard } from '@/components/feature-voting/FeatureVoteCard';
 import { FeatureVoteDetail } from '@/components/feature-voting/FeatureVoteDetail';
+import { useDetailParam } from '@/hooks/use-detail-param';
 import { Dialog, DialogContent } from '@filigran/ui';
 import { VotableFeaturePublicFragment } from '@graphql/generated';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useCallback } from 'react';
 
 interface FeatureVotingItemProps {
   feature: VotableFeaturePublicFragment;
@@ -18,30 +17,10 @@ export const FeatureVotingItem = ({
   serviceInstanceId,
   isAuthenticated,
 }: FeatureVotingItemProps) => {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-
-  // Derived from the URL so a feature detail can be linked to and shared.
-  const isOpen = searchParams.get('featureId') === feature.id;
-
-  const handleClose = useCallback(
-    (open: boolean) => {
-      if (!open) {
-        const params = new URLSearchParams(searchParams.toString());
-        params.delete('featureId');
-
-        const queryString = params.toString();
-        const targetUrl = queryString ? `${pathname}?${queryString}` : pathname;
-
-        router.replace(targetUrl, { scroll: false });
-      }
-    },
-    [router, pathname, searchParams]
-  );
+  const { isOpen, close } = useDetailParam('featureId', feature.id);
 
   return (
-    <li className="group">
+    <li className="h-full">
       <FeatureVoteCard
         feature={feature}
         serviceInstanceId={serviceInstanceId}
@@ -49,7 +28,7 @@ export const FeatureVotingItem = ({
       />
       <Dialog
         open={isOpen}
-        onOpenChange={handleClose}>
+        onOpenChange={(open) => !open && close()}>
         <DialogContent className="flex h-[80vh] max-h-[90vh] w-full max-w-5xl flex-col overflow-hidden p-0">
           <FeatureVoteDetail
             feature={feature}

--- a/apps/frontend/src/components/ui/DetailCard.tsx
+++ b/apps/frontend/src/components/ui/DetailCard.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { MouseEvent, ReactNode, useCallback } from 'react';
+
+interface DetailCardProps {
+  onOpenDetail: () => void;
+  title: string;
+  description: string;
+  media?: ReactNode;
+  extra?: ReactNode;
+  footer?: ReactNode;
+}
+
+export const DetailCard = ({
+  onOpenDetail,
+  title,
+  description,
+  media,
+  extra,
+  footer,
+}: DetailCardProps) => {
+  const handleCardClick = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      const { currentTarget, target } = event;
+      if (!(target instanceof Element)) {
+        return;
+      }
+      if (!currentTarget.contains(target)) {
+        return;
+      }
+      if (target.closest('[data-no-open-detail]')) {
+        return;
+      }
+      onOpenDetail();
+    },
+    [onOpenDetail]
+  );
+
+  return (
+    <div
+      onClick={handleCardClick}
+      className="group flex h-full flex-col overflow-hidden rounded bg-elevation-background-layer-1 hover:cursor-pointer">
+      {media}
+      <div className="flex flex-1 flex-col gap-m p-l group-hover:bg-hover">
+        <div className="flex flex-col gap-m">
+          <h2 className="text-base font-semibold line-clamp-2">
+            <button
+              type="button"
+              data-no-open-detail
+              onClick={() => onOpenDetail()}
+              className="focus-visible:ring-primary text-left focus-visible:outline-none focus-visible:ring-2">
+              {title}
+            </button>
+          </h2>
+          <p className="text-muted-foreground text-sm line-clamp-4 min-h-[5rem]">
+            {description}
+          </p>
+          {extra}
+        </div>
+        {footer && <div className="mt-auto">{footer}</div>}
+      </div>
+    </div>
+  );
+};

--- a/apps/frontend/src/hooks/use-detail-param.test.ts
+++ b/apps/frontend/src/hooks/use-detail-param.test.ts
@@ -1,0 +1,72 @@
+import { renderHook } from '@testing-library/react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDetailParam } from './use-detail-param';
+
+describe('useDetailParam', () => {
+  const replace = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(usePathname).mockReturnValue('/roadmap');
+    vi.mocked(useRouter).mockReturnValue({
+      replace,
+    } as unknown as ReturnType<typeof useRouter>);
+  });
+
+  const mockSearchParams = (query: string) =>
+    vi
+      .mocked(useSearchParams)
+      .mockReturnValue(
+        new URLSearchParams(query) as unknown as ReturnType<
+          typeof useSearchParams
+        >
+      );
+
+  it('reports isOpen when the param matches the value', () => {
+    mockSearchParams('epicId=epic-1');
+
+    const { result } = renderHook(() => useDetailParam('epicId', 'epic-1'));
+
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('reports closed when the param does not match', () => {
+    mockSearchParams('epicId=other');
+
+    const { result } = renderHook(() => useDetailParam('epicId', 'epic-1'));
+
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('sets the param while preserving existing ones on open', () => {
+    mockSearchParams('tab=roadmap');
+
+    const { result } = renderHook(() => useDetailParam('epicId', 'epic-1'));
+    result.current.open();
+
+    expect(replace).toHaveBeenCalledWith('/roadmap?tab=roadmap&epicId=epic-1', {
+      scroll: false,
+    });
+  });
+
+  it('removes only its param on close, keeping the query string', () => {
+    mockSearchParams('tab=roadmap&epicId=epic-1');
+
+    const { result } = renderHook(() => useDetailParam('epicId', 'epic-1'));
+    result.current.close();
+
+    expect(replace).toHaveBeenCalledWith('/roadmap?tab=roadmap', {
+      scroll: false,
+    });
+  });
+
+  it('drops the query string entirely when closing the last param', () => {
+    mockSearchParams('epicId=epic-1');
+
+    const { result } = renderHook(() => useDetailParam('epicId', 'epic-1'));
+    result.current.close();
+
+    expect(replace).toHaveBeenCalledWith('/roadmap', { scroll: false });
+  });
+});

--- a/apps/frontend/src/hooks/use-detail-param.ts
+++ b/apps/frontend/src/hooks/use-detail-param.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useCallback } from 'react';
+
+export const useDetailParam = (key: string, value: string) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const isOpen = searchParams.get(key) === value;
+
+  const open = useCallback(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set(key, value);
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+  }, [router, pathname, searchParams, key, value]);
+
+  const close = useCallback(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete(key);
+    const queryString = params.toString();
+    router.replace(queryString ? `${pathname}?${queryString}` : pathname, {
+      scroll: false,
+    });
+  }, [router, pathname, searchParams, key]);
+
+  return { isOpen, open, close };
+};


### PR DESCRIPTION
# Context
Roadmap and voting cards were too compact and did not display the full short description text (clamped to 3 lines) which is weird because the purpose of a short desc is to be short enough to be fully displayed
Also, both cards were quite similar but defined separately
Therefore, we mutualized both cards to use a common component `DetailCard`, and updated styling to add more space and to display bigger text

## How to test
Validate both updated cards 
Roadmap : 
<img width="414" height="281" alt="Capture d’écran 2026-09-10 à 10 23 40" src="https://github.com/user-attachments/assets/0d6e13c4-e1c2-4f79-be78-46c81a92471b" />

Vote : 
<img width="433" height="215" alt="Capture d’écran 2026-09-10 à 10 23 48" src="https://github.com/user-attachments/assets/957a992a-703f-48dd-98e2-9ffc44f9380f" />



## Related issues

- Related to #3360

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.