### PR TITLE
feat(trials): show XTM One URL and render platform URLs as external links (#3371)

### DIFF
--- a/apps/frontend/graphql/deployment/deployment.query.graphql
+++ b/apps/frontend/graphql/deployment/deployment.query.graphql
@@ -4,6 +4,7 @@ fragment TrialsProduct on DeploymentRequest {
   hub_status
   platform_id
   platform_url
+  url
 }
 
 fragment TrialsRow on DeploymentRequest {
@@ -24,6 +25,7 @@ fragment TrialsRow on DeploymentRequest {
   platform_identifier
   platform_id
   platform_url
+  url
   children {
     ...TrialsProduct
   }

--- a/apps/frontend/graphql/generated.ts
+++ b/apps/frontend/graphql/generated.ts
@@ -3156,9 +3156,9 @@ export type TrialsUpdateDeploymentQuotaCapacityMutationVariables = Exact<{
 
 export type TrialsUpdateDeploymentQuotaCapacityMutation = { __typename?: 'Mutation', updateDeploymentQuotaCapacity: { __typename?: 'Success', success: boolean } };
 
-export type TrialsProductFragment = { __typename?: 'DeploymentRequest', id: string, platform_identifier: PlatformIdentifier | null, hub_status: DeploymentRequestHubStatus, platform_id: string | null, platform_url: string | null };
+export type TrialsProductFragment = { __typename?: 'DeploymentRequest', id: string, platform_identifier: PlatformIdentifier | null, hub_status: DeploymentRequestHubStatus, platform_id: string | null, platform_url: string | null, url: string | null };
 
-export type TrialsRowFragment = { __typename?: 'DeploymentRequest', id: string, service_instance_id: any, ordering: number, hub_status: DeploymentRequestHubStatus, requester_email: string | null, organization_name: string | null, organization_requester_id: any, region: DeploymentRequestPlatformRegion, request_date: any, start_date: any | null, end_date: any | null, cancellation_date: any | null, cancellation_user_email: string | null, cancellation_reason: string | null, platform_identifier: PlatformIdentifier | null, platform_id: string | null, platform_url: string | null, children: Array<{ __typename?: 'DeploymentRequest', id: string, platform_identifier: PlatformIdentifier | null, hub_status: DeploymentRequestHubStatus, platform_id: string | null, platform_url: string | null }> | null };
+export type TrialsRowFragment = { __typename?: 'DeploymentRequest', id: string, service_instance_id: any, ordering: number, hub_status: DeploymentRequestHubStatus, requester_email: string | null, organization_name: string | null, organization_requester_id: any, region: DeploymentRequestPlatformRegion, request_date: any, start_date: any | null, end_date: any | null, cancellation_date: any | null, cancellation_user_email: string | null, cancellation_reason: string | null, platform_identifier: PlatformIdentifier | null, platform_id: string | null, platform_url: string | null, url: string | null, children: Array<{ __typename?: 'DeploymentRequest', id: string, platform_identifier: PlatformIdentifier | null, hub_status: DeploymentRequestHubStatus, platform_id: string | null, platform_url: string | null, url: string | null }> | null };
 
 export type TrialsQuotaFragment = { __typename?: 'DeploymentAvailability', id: string, region: DeploymentRequestPlatformRegion, availableCount: number, capacity: number, platform_identifier: PlatformIdentifier | null };
 
@@ -3172,7 +3172,7 @@ export type TrialsListQueryVariables = Exact<{
 }>;
 
 
-export type TrialsListQuery = { __typename?: 'Query', deploymentRequestsList: { __typename?: 'DeploymentRequestConnection', totalCount: number, edges: Array<{ __typename?: 'DeploymentRequestEdge', node: { __typename?: 'DeploymentRequest', id: string, service_instance_id: any, ordering: number, hub_status: DeploymentRequestHubStatus, requester_email: string | null, organization_name: string | null, organization_requester_id: any, region: DeploymentRequestPlatformRegion, request_date: any, start_date: any | null, end_date: any | null, cancellation_date: any | null, cancellation_user_email: string | null, cancellation_reason: string | null, platform_identifier: PlatformIdentifier | null, platform_id: string | null, platform_url: string | null, children: Array<{ __typename?: 'DeploymentRequest', id: string, platform_identifier: PlatformIdentifier | null, hub_status: DeploymentRequestHubStatus, platform_id: string | null, platform_url: string | null }> | null } }> } };
+export type TrialsListQuery = { __typename?: 'Query', deploymentRequestsList: { __typename?: 'DeploymentRequestConnection', totalCount: number, edges: Array<{ __typename?: 'DeploymentRequestEdge', node: { __typename?: 'DeploymentRequest', id: string, service_instance_id: any, ordering: number, hub_status: DeploymentRequestHubStatus, requester_email: string | null, organization_name: string | null, organization_requester_id: any, region: DeploymentRequestPlatformRegion, request_date: any, start_date: any | null, end_date: any | null, cancellation_date: any | null, cancellation_user_email: string | null, cancellation_reason: string | null, platform_identifier: PlatformIdentifier | null, platform_id: string | null, platform_url: string | null, url: string | null, children: Array<{ __typename?: 'DeploymentRequest', id: string, platform_identifier: PlatformIdentifier | null, hub_status: DeploymentRequestHubStatus, platform_id: string | null, platform_url: string | null, url: string | null }> | null } }> } };
 
 export type TrialsQuotasQueryVariables = Exact<{
   platformIdentifier: InputMaybe<PlatformIdentifier>;
@@ -3603,6 +3603,7 @@ export const TrialsProductFragmentDoc = `
   hub_status
   platform_id
   platform_url
+  url
 }
     `;
 export const TrialsRowFragmentDoc = `
@@ -3624,6 +3625,7 @@ export const TrialsRowFragmentDoc = `
   platform_identifier
   platform_id
   platform_url
+  url
   children {
     ...TrialsProduct
   }

--- a/apps/frontend/src/components/trials/tab/TrialsExternalLink.test.tsx
+++ b/apps/frontend/src/components/trials/tab/TrialsExternalLink.test.tsx
@@ -1,0 +1,37 @@
+import { TrialsExternalLink } from '@/components/trials/tab/TrialsExternalLink';
+import testRender from '@/utils/test/test-render';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+describe('TrialsExternalLink', () => {
+  it('should render a scheme-less url as an external https link', () => {
+    testRender(<TrialsExternalLink url="opencti.example.com" />);
+
+    const link = screen.getByRole('link', { name: 'opencti.example.com' });
+    expect(link).toHaveAttribute('href', 'https://opencti.example.com/');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('should render unsafe urls as plain text', () => {
+    testRender(<TrialsExternalLink url="javascript:alert(1)" />);
+
+    expect(
+      screen.queryByRole('link', { name: 'javascript:alert(1)' })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('javascript:alert(1)')).toBeInTheDocument();
+  });
+
+  it('should fall back to a dash when no url is provided', () => {
+    testRender(<TrialsExternalLink url={null} />);
+
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
+
+  it('should fall back to a dash for a whitespace-only url', () => {
+    testRender(<TrialsExternalLink url="   " />);
+
+    expect(screen.getByText('-')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/trials/tab/TrialsExternalLink.tsx
+++ b/apps/frontend/src/components/trials/tab/TrialsExternalLink.tsx
@@ -1,0 +1,33 @@
+'use client';
+import { cn } from '@/lib/utils';
+import { toExternalHref } from '@/utils/external-url';
+
+interface TrialsExternalLinkProps {
+  url: string | null | undefined;
+  className?: string;
+  fallback?: string;
+}
+
+export const TrialsExternalLink = ({
+  url,
+  className,
+  fallback = '-',
+}: TrialsExternalLinkProps) => {
+  const trimmedUrl = url?.trim();
+  const href = toExternalHref(trimmedUrl);
+
+  if (!href) {
+    return <span className={className}>{trimmedUrl || fallback}</span>;
+  }
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn('text-text-brand-primary underline', className)}
+      onClick={(event) => event.stopPropagation()}>
+      {trimmedUrl}
+    </a>
+  );
+};

--- a/apps/frontend/src/components/trials/tab/TrialsProductValues.test.tsx
+++ b/apps/frontend/src/components/trials/tab/TrialsProductValues.test.tsx
@@ -19,6 +19,7 @@ const makeProduct = (
   hub_status: DeploymentRequestHubStatus.Active,
   platform_id: platformId,
   platform_url: null,
+  url: null,
   service_instance_id: `instance-${platformIdentifier}`,
 });
 
@@ -59,5 +60,26 @@ describe('TrialsProductValues', () => {
     // Then
     expect(screen.getByText('-')).toBeInTheDocument();
     expect(screen.queryByText('OPENCTI')).not.toBeInTheDocument();
+  });
+
+  it('should render values as clickable external links when asLink is set', () => {
+    const products = [
+      {
+        ...makeProduct(PlatformIdentifier.Xtmone, null),
+        url: 'xtmone.example.io',
+      },
+    ];
+
+    testRender(
+      <TrialsProductValues
+        products={products}
+        valueOf={(product) => product.url}
+        asLink
+      />
+    );
+
+    const link = screen.getByRole('link', { name: 'xtmone.example.io' });
+    expect(link).toHaveAttribute('href', 'https://xtmone.example.io/');
+    expect(link).toHaveAttribute('target', '_blank');
   });
 });

--- a/apps/frontend/src/components/trials/tab/TrialsProductValues.tsx
+++ b/apps/frontend/src/components/trials/tab/TrialsProductValues.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { TrialsExternalLink } from '@/components/trials/tab/TrialsExternalLink';
 import {
   Tooltip,
   TooltipContent,
@@ -10,11 +11,13 @@ import { TrialsProductFragment } from '@graphql/generated';
 interface TrialsProductValuesProps {
   products: readonly TrialsProductFragment[];
   valueOf: (product: TrialsProductFragment) => string | null | undefined;
+  asLink?: boolean;
 }
 
 export const TrialsProductValues = ({
   products,
   valueOf,
+  asLink = false,
 }: TrialsProductValuesProps) => {
   const valuedProducts = products.filter((product) => !!valueOf(product));
 
@@ -24,25 +27,36 @@ export const TrialsProductValues = ({
 
   return (
     <div className="flex flex-col gap-xs">
-      {valuedProducts.map((product) => (
-        <TooltipProvider
-          key={product.id}
-          delayDuration={200}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="truncate cursor-help">
-                <span className="text-text-default-secondary">
-                  {product.platform_identifier?.toUpperCase()}
-                </span>{' '}
-                {valueOf(product)}
-              </span>
-            </TooltipTrigger>
-            <TooltipContent className="max-w-md">
-              {valueOf(product)}
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      ))}
+      {valuedProducts.map((product) => {
+        const value = valueOf(product);
+        if (!value) {
+          return null;
+        }
+        return (
+          <TooltipProvider
+            key={product.id}
+            delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="flex items-center gap-xs cursor-help">
+                  <span className="text-text-default-secondary">
+                    {product.platform_identifier?.toUpperCase()}
+                  </span>
+                  {asLink ? (
+                    <TrialsExternalLink
+                      url={value}
+                      className="truncate"
+                    />
+                  ) : (
+                    <span className="truncate">{value}</span>
+                  )}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-md">{value}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        );
+      })}
     </div>
   );
 };

--- a/apps/frontend/src/components/trials/tab/TrialsProducts.test.tsx
+++ b/apps/frontend/src/components/trials/tab/TrialsProducts.test.tsx
@@ -17,6 +17,7 @@ const makeProduct = (
   hub_status: hubStatus,
   platform_id: null,
   platform_url: null,
+  url: null,
 });
 
 const badgeOf = (product: string) =>

--- a/apps/frontend/src/components/trials/tab/TrialsTab.tsx
+++ b/apps/frontend/src/components/trials/tab/TrialsTab.tsx
@@ -5,6 +5,7 @@ import {
   formatCancellationReason,
   sortProducts,
 } from '@/components/trials/tab/trials-tab.utils';
+import { TrialsExternalLink } from '@/components/trials/tab/TrialsExternalLink';
 import { TrialsProducts } from '@/components/trials/tab/TrialsProducts';
 import { TrialsProductValues } from '@/components/trials/tab/TrialsProductValues';
 import { useTrialsListLocalstorage } from '@/components/trials/trial-list-localstorage';
@@ -72,7 +73,7 @@ type TrialsCellProps = { row: { original: TrialsRowFragment } };
 type Translate = (key: string) => string;
 type TrialsProductValue = Pick<
   TrialsProductFragment,
-  'platform_id' | 'platform_url'
+  'platform_id' | 'platform_url' | 'url'
 >;
 
 const dateColumn = (
@@ -96,21 +97,34 @@ const productColumn = (
   id: 'platform_id' | 'platform_url' | 'registration_status',
   header: string,
   scope: TrialsScope,
-  valueOf: (product: TrialsProductValue) => string | null | undefined
+  valueOf: (product: TrialsProductValue) => string | null | undefined,
+  asLink = false
 ): TrialsColumn => ({
   accessorKey: id,
   id,
   enableSorting: false,
   header,
-  cell: ({ row }: TrialsCellProps) =>
-    scope.kind === 'bundle' ? (
-      <TrialsProductValues
-        products={row.original.children ?? []}
-        valueOf={valueOf}
-      />
-    ) : (
-      <span className="truncate">{valueOf(row.original) || '-'}</span>
-    ),
+  cell: ({ row }: TrialsCellProps) => {
+    if (scope.kind === 'bundle') {
+      return (
+        <TrialsProductValues
+          products={row.original.children ?? []}
+          valueOf={valueOf}
+          asLink={asLink}
+        />
+      );
+    }
+    const value = valueOf(row.original);
+    if (asLink) {
+      return (
+        <TrialsExternalLink
+          url={value}
+          className="truncate"
+        />
+      );
+    }
+    return <span className="truncate">{value || '-'}</span>;
+  },
 });
 
 const productColumns = (scope: TrialsScope, t: Translate): TrialsColumn[] => [
@@ -124,7 +138,8 @@ const productColumns = (scope: TrialsScope, t: Translate): TrialsColumn[] => [
     'platform_url',
     t('TrialsDashboard.Columns.PlatformUrl'),
     scope,
-    (product) => product.platform_url
+    (product) => product.platform_url ?? product.url,
+    true
   ),
   productColumn(
     'registration_status',


### PR DESCRIPTION
# Context
On the admin **Manage Trials** (bundle) dashboard, the "Platform URL" column had two problems:

- **XTM One URL was missing.** The frontend only fetched `platform_url`, which is populated from `PlatformConfiguration` when OpenCTI/OpenAEV *register*. XTM One is provisioned by platform, so its URL lives in the deployment request's own `url` column
- **URLs were plain strings**, they weren't clickable

## How to test
Validate that 
- `XTM One URL` is displayed
- Links are clickable, external urls are properly opening
<img width="1155" height="127" alt="Capture d’écran 2026-09-10 à 12 40 13" src="https://github.com/user-attachments/assets/a844fe53-3fd7-4cfa-87f8-cfb36d50ce99" />

## Related issues

- Related to #3371

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.