### PR TITLE
fix(frontend): redirect to current page after login from public header (#3369)

### DIFF
--- a/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/xtm-platform-roadmap/feature-voting/page.test.tsx
+++ b/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/xtm-platform-roadmap/feature-voting/page.test.tsx
@@ -1,0 +1,61 @@
+import { loadCurrentUser } from '@/utils/load-me-user';
+import Page from '@app/(public)/[locale]/cybersecurity-solutions/xtm-platform-roadmap/feature-voting/page';
+import { render, screen } from '@testing-library/react';
+import { redirect } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const APP_FEATURE_VOTING_HREF =
+  '/app/service/xtm_platform_roadmap/instance-1/feature-voting';
+
+vi.mock('@/utils/load-me-user', () => ({
+  loadCurrentUser: vi.fn(),
+}));
+
+vi.mock('@/relay/server-portal-api-fetch', () => ({
+  serverFetchGraphQL: vi.fn(async () => ({
+    data: { seoServiceInstance: { id: 'instance-1' } },
+  })),
+}));
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: async () => Object.assign((key: string) => key, {}),
+  setRequestLocale: vi.fn(),
+}));
+
+vi.mock('@/utils/generate-metadata', () => ({
+  buildSeoPageMetadata: vi.fn((options: { title: string }) => ({
+    title: options.title,
+  })),
+  getBaseUrl: vi.fn(async () => 'https://hub.filigran.io'),
+}));
+
+vi.mock('@/components/feature-voting/FeatureVotingList', () => ({
+  FeatureVotingList: () => <div data-testid="feature-voting-list" />,
+}));
+
+describe('public feature-voting page', () => {
+  beforeEach(() => {
+    vi.mocked(loadCurrentUser).mockReset();
+    vi.mocked(redirect).mockReset();
+  });
+
+  it('redirects logged-in users to the private in-app voting page', async () => {
+    vi.mocked(loadCurrentUser).mockResolvedValue({
+      id: 'user-1',
+    } as Awaited<ReturnType<typeof loadCurrentUser>>);
+
+    await Page({ params: Promise.resolve({ locale: 'en' }) });
+
+    expect(redirect).toHaveBeenCalledWith(APP_FEATURE_VOTING_HREF);
+  });
+
+  it('renders the public list for anonymous users', async () => {
+    vi.mocked(loadCurrentUser).mockResolvedValue(null);
+
+    const element = await Page({ params: Promise.resolve({ locale: 'en' }) });
+    render(element);
+
+    expect(screen.getByTestId('feature-voting-list')).toBeInTheDocument();
+    expect(redirect).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/xtm-platform-roadmap/feature-voting/page.tsx
+++ b/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/xtm-platform-roadmap/feature-voting/page.tsx
@@ -1,7 +1,9 @@
 import { FeatureVotingList } from '@/components/feature-voting/FeatureVotingList';
+import { getFeatureVotingPrivatePath } from '@/components/feature-voting/feature-voting-path';
 import type { PublicLocale } from '@/i18n/config';
 import { serverFetchGraphQL } from '@/relay/server-portal-api-fetch';
 import { buildSeoPageMetadata, getBaseUrl } from '@/utils/generate-metadata';
+import { loadCurrentUser } from '@/utils/load-me-user';
 import {
   PUBLIC_CYBERSECURITY_SOLUTIONS_PATH,
   XTM_PLATFORM_ROADMAP_SLUG,
@@ -12,6 +14,7 @@ import SeoServiceInstanceQuery, {
 } from '@generated/seoServiceInstanceQuery.graphql';
 import { Metadata } from 'next';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { redirect } from 'next/navigation';
 import { cache } from 'react';
 
 const ROADMAP_PATH = `/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${XTM_PLATFORM_ROADMAP_SLUG}`;
@@ -55,6 +58,11 @@ const Page = async ({
   setRequestLocale(locale);
 
   const serviceInstance = await getRoadmapServiceInstance();
+
+  const user = await loadCurrentUser();
+  if (user) {
+    redirect(getFeatureVotingPrivatePath(serviceInstance.id));
+  }
 
   return (
     <FeatureVotingList

--- a/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/xtm-platform-trial/page.test.tsx
+++ b/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/xtm-platform-trial/page.test.tsx
@@ -1,4 +1,4 @@
-import { loadMeUser } from '@/utils/load-me-user';
+import { loadCurrentUser } from '@/utils/load-me-user';
 import { isFeatureEnabled } from '@/utils/settings.service';
 import Page, {
   generateMetadata,
@@ -8,7 +8,7 @@ import { notFound, redirect } from 'next/navigation';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/utils/load-me-user', () => ({
-  loadMeUser: vi.fn(),
+  loadCurrentUser: vi.fn(),
 }));
 
 vi.mock('@/utils/settings.service', () => ({
@@ -37,16 +37,16 @@ vi.mock(
 
 describe('public xtm-platform-trial page', () => {
   beforeEach(() => {
-    vi.mocked(loadMeUser).mockReset();
+    vi.mocked(loadCurrentUser).mockReset();
     vi.mocked(redirect).mockReset();
     vi.mocked(notFound).mockClear();
     vi.mocked(isFeatureEnabled).mockReset().mockResolvedValue(true);
   });
 
   it('redirects logged-in users to the private xtm-platform-trial page', async () => {
-    vi.mocked(loadMeUser).mockResolvedValue({
+    vi.mocked(loadCurrentUser).mockResolvedValue({
       id: 'user-1',
-    } as Awaited<ReturnType<typeof loadMeUser>>);
+    } as Awaited<ReturnType<typeof loadCurrentUser>>);
 
     await Page({ params: Promise.resolve({ locale: 'en' }) });
 
@@ -54,7 +54,7 @@ describe('public xtm-platform-trial page', () => {
   });
 
   it('renders the breadcrumb and page for anonymous users', async () => {
-    vi.mocked(loadMeUser).mockRejectedValue(new Error('not logged in'));
+    vi.mocked(loadCurrentUser).mockResolvedValue(null);
 
     const element = await Page({ params: Promise.resolve({ locale: 'en' }) });
     render(element);

--- a/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/xtm-platform-trial/page.tsx
+++ b/apps/frontend/app/(public)/[locale]/cybersecurity-solutions/xtm-platform-trial/page.tsx
@@ -8,7 +8,7 @@ import {
   getBaseUrl,
   stringifyJsonLd,
 } from '@/utils/generate-metadata';
-import { loadMeUser } from '@/utils/load-me-user';
+import { loadCurrentUser } from '@/utils/load-me-user';
 import {
   APP_PATH,
   PUBLIC_CYBERSECURITY_SOLUTIONS_PATH,
@@ -41,14 +41,6 @@ export async function generateMetadata({
     imageAlt: t('Service.Trials.XtmPlatform.Page.PitchTitle'),
   });
 }
-
-const loadCurrentUser = async () => {
-  try {
-    return await loadMeUser();
-  } catch {
-    return null;
-  }
-};
 
 const Page = async ({
   params,

--- a/apps/frontend/src/components/layout/PublicHeaderAuthButtons.test.tsx
+++ b/apps/frontend/src/components/layout/PublicHeaderAuthButtons.test.tsx
@@ -1,0 +1,45 @@
+import { PublicHeaderAuthButtons } from '@/components/layout/PublicHeaderAuthButtons';
+import { PUBLIC_FEATURE_VOTING_PATH } from '@/utils/path/constant';
+import testRender from '@/utils/test/test-render';
+import { screen } from '@testing-library/react';
+import { usePathname } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const encoded = (path: string) => encodeURIComponent(btoa(path));
+
+describe('PublicHeaderAuthButtons', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults login/sign-up to the app home on a regular public page', () => {
+    vi.mocked(usePathname).mockReturnValue(
+      '/en/cybersecurity-solutions/some-library'
+    );
+
+    testRender(<PublicHeaderAuthButtons />);
+
+    expect(screen.getByText('PublicLayout.Login').closest('a')).toHaveAttribute(
+      'href',
+      '/auth/oidc'
+    );
+    expect(
+      screen.getByText('PublicLayout.SignUp').closest('a')
+    ).toHaveAttribute('href', '/sign-up');
+  });
+
+  it('carries the current path on the public feature-voting page', () => {
+    const pathname = `/en${PUBLIC_FEATURE_VOTING_PATH}`;
+    vi.mocked(usePathname).mockReturnValue(pathname);
+
+    testRender(<PublicHeaderAuthButtons />);
+
+    expect(screen.getByText('PublicLayout.Login').closest('a')).toHaveAttribute(
+      'href',
+      `/auth/oidc?redirect=${encoded(pathname)}`
+    );
+    expect(
+      screen.getByText('PublicLayout.SignUp').closest('a')
+    ).toHaveAttribute('href', `/sign-up?redirect=${encoded(pathname)}`);
+  });
+});

--- a/apps/frontend/src/components/layout/PublicHeaderAuthButtons.tsx
+++ b/apps/frontend/src/components/layout/PublicHeaderAuthButtons.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { PUBLIC_FEATURE_VOTING_PATH } from '@/utils/path/constant';
+import { buildOidcRedirect, buildSignupRedirect } from '@/utils/redirect';
+import { Button } from '@filigran/ui/servers';
+import { useTranslations } from 'next-intl';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+export const PublicHeaderAuthButtons = () => {
+  const t = useTranslations();
+  const pathname = usePathname();
+  const redirectTarget = pathname?.endsWith(PUBLIC_FEATURE_VOTING_PATH)
+    ? pathname
+    : undefined;
+
+  return (
+    <>
+      <Button
+        asChild
+        variant="secondary">
+        <Link
+          href={buildOidcRedirect(redirectTarget)}
+          prefetch={false}>
+          {t('PublicLayout.Login')}
+        </Link>
+      </Button>
+      <Button
+        asChild
+        className="whitespace-nowrap">
+        <Link href={buildSignupRedirect(redirectTarget)}>
+          {t('PublicLayout.SignUp')}
+        </Link>
+      </Button>
+    </>
+  );
+};

--- a/apps/frontend/src/components/layout/PublicHeaderContent.tsx
+++ b/apps/frontend/src/components/layout/PublicHeaderContent.tsx
@@ -1,5 +1,5 @@
+import { PublicHeaderAuthButtons } from '@/components/layout/PublicHeaderAuthButtons';
 import { PublicMobileMenuButton } from '@/components/menu/navigation/public/PublicMobileMenuButton';
-import { Button } from '@filigran/ui/servers';
 import LogoXTMDark from '@public/logo_xtm_hub_dark.svg';
 import { getTranslations } from 'next-intl/server';
 import Link from 'next/link';
@@ -26,20 +26,7 @@ export const PublicHeaderContent = async ({
         <span className="sr-only">{t('Metadata.SiteName')}</span>
       </Link>
       <div className="flex items-center gap-s ml-auto">
-        <Button
-          asChild
-          variant="secondary">
-          <Link
-            href="/auth/oidc"
-            prefetch={false}>
-            {t('PublicLayout.Login')}
-          </Link>
-        </Button>
-        <Button
-          asChild
-          className="whitespace-nowrap">
-          <Link href={`/sign-up`}>{t('PublicLayout.SignUp')}</Link>
-        </Button>
+        <PublicHeaderAuthButtons />
         <div className="md:hidden flex items-center">
           <PublicMobileMenuButton
             visibleServiceSlugs={visibleServiceSlugs}

--- a/apps/frontend/src/components/service/trial-instances/xtm-platform-trial/PublicXtmPlatformTrialPanel.tsx
+++ b/apps/frontend/src/components/service/trial-instances/xtm-platform-trial/PublicXtmPlatformTrialPanel.tsx
@@ -1,5 +1,6 @@
 import { XtmPlatformTrialMessagePanel } from '@/components/service/trial-instances/xtm-platform-trial/XtmPlatformTrialMessagePanel';
 import { APP_PATH } from '@/utils/path/constant';
+import { buildOidcRedirect, buildSignupRedirect } from '@/utils/redirect';
 import { Button } from '@filigran/ui/servers';
 import { getTranslations } from 'next-intl/server';
 import Link from 'next/link';
@@ -8,7 +9,6 @@ export const PublicXtmPlatformTrialPanel = async () => {
   const t = await getTranslations();
 
   const redirectPath = `/${APP_PATH}/service/xtm-platform-trial`;
-  const encodedRedirect = encodeURIComponent(btoa(redirectPath));
 
   return (
     <XtmPlatformTrialMessagePanel
@@ -20,13 +20,13 @@ export const PublicXtmPlatformTrialPanel = async () => {
             asChild
             variant="secondary">
             <Link
-              href={`/auth/oidc?redirect=${encodedRedirect}`}
+              href={buildOidcRedirect(redirectPath)}
               prefetch={false}>
               {t('PublicLayout.Login')}
             </Link>
           </Button>
           <Button asChild>
-            <Link href={`/sign-up?redirect=${encodedRedirect}`}>
+            <Link href={buildSignupRedirect(redirectPath)}>
               {t('PublicLayout.SignUp')}
             </Link>
           </Button>

--- a/apps/frontend/src/utils/load-me-user.test.ts
+++ b/apps/frontend/src/utils/load-me-user.test.ts
@@ -1,5 +1,5 @@
 import serverPortalApiFetch from '@/relay/server-portal-api-fetch';
-import { loadMeUser } from '@/utils/load-me-user';
+import { loadCurrentUser, loadMeUser } from '@/utils/load-me-user';
 import MeLoaderQuery from '@generated/meLoaderQuery.graphql';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -34,5 +34,23 @@ describe('loadMeUser', () => {
     } as never);
 
     await expect(loadMeUser()).resolves.toBeNull();
+  });
+});
+
+describe('loadCurrentUser', () => {
+  it('swallows a rejected identity request and resolves null', async () => {
+    vi.mocked(serverPortalApiFetch).mockRejectedValue(
+      new Error('unauthenticated')
+    );
+
+    await expect(loadCurrentUser()).resolves.toBeNull();
+  });
+
+  it('returns the user when the identity request succeeds', async () => {
+    vi.mocked(serverPortalApiFetch).mockResolvedValue({
+      data: { me: { id: 'user-1' } },
+    } as never);
+
+    await expect(loadCurrentUser()).resolves.toEqual({ id: 'user-1' });
   });
 });

--- a/apps/frontend/src/utils/load-me-user.ts
+++ b/apps/frontend/src/utils/load-me-user.ts
@@ -25,3 +25,11 @@ export const loadMeUser = async () => {
   >(MeLoaderQuery, {}, { cache: 'no-store' })) as MeResponse;
   return meResponse.data.me ?? null;
 };
+
+export const loadCurrentUser = async () => {
+  try {
+    return await loadMeUser();
+  } catch {
+    return null;
+  }
+};

--- a/apps/frontend/src/utils/path/constant.ts
+++ b/apps/frontend/src/utils/path/constant.ts
@@ -2,6 +2,8 @@ export const PUBLIC_CYBERSECURITY_SOLUTIONS_PATH = 'cybersecurity-solutions';
 
 export const XTM_PLATFORM_ROADMAP_SLUG = 'xtm-platform-roadmap';
 
+export const PUBLIC_FEATURE_VOTING_PATH = `/${PUBLIC_CYBERSECURITY_SOLUTIONS_PATH}/${XTM_PLATFORM_ROADMAP_SLUG}/feature-voting`;
+
 export const APP_PATH = 'app';
 
 export const XTM_PLATFORM_TRIAL_PATH = `/${APP_PATH}/service/xtm-platform-trial`;

--- a/apps/frontend/src/utils/redirect.test.ts
+++ b/apps/frontend/src/utils/redirect.test.ts
@@ -3,6 +3,7 @@ import { getClientEnvironment } from '@/relay/environment/registry';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildLoginRedirect,
+  buildOidcRedirect,
   decodeSafeRedirect,
   isSafeRedirect,
 } from './redirect';
@@ -90,6 +91,35 @@ describe('buildLoginRedirect', () => {
     const path = '/app/manage/user?tab=pending&page=2';
     const loginUrl = buildLoginRedirect(path);
     const b64 = new URLSearchParams(loginUrl.split('?')[1]).get('redirect');
+    expect(decodeSafeRedirect(b64)).toBe(path);
+  });
+});
+
+describe('buildOidcRedirect', () => {
+  it.each([[null], [undefined], ['']])('returns /auth/oidc for %s', (value) => {
+    expect(buildOidcRedirect(value)).toBe('/auth/oidc');
+  });
+
+  it('encodes the pathname as encodeURIComponent(btoa(pathname))', () => {
+    const path = '/app/service/xtm_platform_roadmap/abc-123/feature-voting';
+    const expected = `/auth/oidc?redirect=${encodeURIComponent(btoa(path))}`;
+    expect(buildOidcRedirect(path)).toBe(expected);
+  });
+
+  it('encodes + in base64 as %2B', () => {
+    const path = '/~~';
+    const result = buildOidcRedirect(path);
+    // Sanity check: this path's base64 genuinely contains a + so the guard is exercised
+    expect(btoa(path)).toContain('+');
+    // qs decodes a raw + as a space, so the + must be percent-encoded as %2B
+    expect(result.split('?redirect=')[1]).toContain('%2B');
+    expect(result.split('?redirect=')[1]).not.toContain('+');
+  });
+
+  it('round-trips through URLSearchParams and decodeSafeRedirect', () => {
+    const path = '/cybersecurity-solutions/xtm-platform-roadmap/feature-voting';
+    const url = buildOidcRedirect(path);
+    const b64 = new URLSearchParams(url.split('?')[1]).get('redirect');
     expect(decodeSafeRedirect(b64)).toBe(path);
   });
 });

--- a/apps/frontend/src/utils/redirect.ts
+++ b/apps/frontend/src/utils/redirect.ts
@@ -9,29 +9,27 @@ export const isSafeRedirect = (url: string): boolean => {
   return url.startsWith('/') && !url.startsWith('//');
 };
 
-/**
- * Builds a safe login redirect URL with the current pathname base64-encoded
- * as a query param. Returns '/login' when no pathname is provided.
- * Single canonical way to produce a login redirect URL on the frontend.
- */
-export const buildLoginRedirect = (
+// Canonical builder for the auth redirect URLs. Encodes the pathname as a
+// `redirect` query param, or returns `base` unchanged when none is given.
+const buildAuthRedirect = (
+  base: string,
   pathname: string | null | undefined
 ): string => {
-  if (!pathname) return '/login';
-  return `/login?redirect=${encodeURIComponent(btoa(pathname))}`;
+  if (!pathname) return base;
+  return `${base}?redirect=${encodeURIComponent(btoa(pathname))}`;
 };
 
-/**
- * Builds a safe signup redirect URL with the current pathname base64-encoded
- * as a query param.
- * Returns '/sign-up' when no pathname is provided.
- */
+export const buildLoginRedirect = (
+  pathname: string | null | undefined
+): string => buildAuthRedirect('/login', pathname);
+
 export const buildSignupRedirect = (
   pathname: string | null | undefined
-): string => {
-  if (!pathname) return '/sign-up';
-  return `/sign-up?redirect=${encodeURIComponent(btoa(pathname))}`;
-};
+): string => buildAuthRedirect('/sign-up', pathname);
+
+export const buildOidcRedirect = (
+  pathname: string | null | undefined
+): string => buildAuthRedirect('/auth/oidc', pathname);
 
 /**
  * Decodes a base64-encoded redirect parameter and validates it is a safe


### PR DESCRIPTION
# Context

On the public feature-voting page, clicking `Login` (or `Sign-up`) in the header sent the visitor to `/app` after authentication, dropping them on the app home
Now, logging in from that page lands the visitor on the private in-app voting page
How it works: 
- On the feature-voting page only, the header's Login/Sign-up carry the current public path as a base64 `?redirect= param`
- After OIDC, the backend returns the visitor to that public path
- The public voting page detects the authenticated user server-side and redirects to the private in-app voting page

*Scoped to feature-voting only: other public pages keep the plain default (out of scope)*

Refactors bundled in (DRY, no behaviour change):
- Collapsed the login/sign-up/oidc redirect builders behind one shared `buildAuthRedirect` in `redirect.ts`
- Hoisted a single shared `loadCurrentUser` into `load-me-user.ts`, replacing duplicate local wrappers in the voting and trial pages.

## How to test
- go on public voting page
- click on login
- log in with auth0
- it should redirect you on the voting page, authenticated

https://github.com/user-attachments/assets/04508119-f5aa-46b8-81bf-31edbfc9ee1e

## Related issues

- Related to #3369

# Checklist

## Quality

- [ ] I consider this work complete and ready for review
- [ ] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [ ] I made sure my code meets development guidelines
- [ ] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.