### PR TITLE
fix(ci): implement retry mechanism for image pulls with exponential backoff (#3388)

### DIFF
--- a/.github/actions/retry-with-backoff/action.yml
+++ b/.github/actions/retry-with-backoff/action.yml
@@ -1,0 +1,44 @@
+name: 'Retry with exponential backoff'
+description: 'Runs a shell command, retrying with exponential backoff on failure.'
+inputs:
+  command:
+    description: 'Shell command to execute (can be multi-line).'
+    required: true
+  max-attempts:
+    description: 'Maximum number of attempts before giving up.'
+    required: false
+    default: '5'
+  initial-delay-seconds:
+    description: 'Delay (in seconds) before the first retry. Doubles after every failed attempt.'
+    required: false
+    default: '2'
+runs:
+  using: 'composite'
+  steps:
+    - name: Run command with retries
+      shell: bash
+      run: |
+        script_path="${RUNNER_TEMP}/retry-command-${GITHUB_RUN_ID}-${RANDOM}.sh"
+        cat <<'RETRY_COMMAND_EOF' > "${script_path}"
+        ${{ inputs.command }}
+        RETRY_COMMAND_EOF
+        chmod +x "${script_path}"
+
+        max_attempts="${{ inputs.max-attempts }}"
+        delay="${{ inputs.initial-delay-seconds }}"
+        attempt=1
+
+        until bash "${script_path}"; do
+          if (( attempt >= max_attempts )); then
+            echo "❌ Command failed after ${attempt} attempts"
+            rm -f "${script_path}"
+            exit 1
+          fi
+          echo "⚠️ Attempt ${attempt}/${max_attempts} failed. Retrying in ${delay}s..."
+          sleep "${delay}"
+          delay=$(( delay * 2 ))
+          attempt=$(( attempt + 1 ))
+        done
+
+        echo "✅ Command succeeded on attempt ${attempt}/${max_attempts}"
+        rm -f "${script_path}"

--- a/.github/actions/retry-with-backoff/action.yml
+++ b/.github/actions/retry-with-backoff/action.yml
@@ -28,7 +28,7 @@ runs:
         delay="${{ inputs.initial-delay-seconds }}"
         attempt=1
 
-        until bash "${script_path}"; do
+        until bash -e -o pipefail "${script_path}"; do
           if (( attempt >= max_attempts )); then
             echo "❌ Command failed after ${attempt} attempts"
             rm -f "${script_path}"

--- a/.github/workflows/dockerbuild-ci.yml
+++ b/.github/workflows/dockerbuild-ci.yml
@@ -482,6 +482,9 @@ jobs:
       github.event_name == 'pull_request' &&
       !contains(github.event.pull_request.labels.*.name, 'skip-feature-env')
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - name: Install AWX cli
         run: pip install awxkit
 
@@ -617,6 +620,9 @@ jobs:
       github.event_name != 'merge_group' &&
       (needs.build-images-prod.result == 'success')
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - name: Install AWX cli
         run: pip install awxkit
 

--- a/.github/workflows/dockerbuild-ci.yml
+++ b/.github/workflows/dockerbuild-ci.yml
@@ -217,6 +217,13 @@ jobs:
           cp -r ./apps/backend/tests/seeds ./apps/e2e/seeds
           cp ./apps/backend/tests/test-utils.ts ./apps/e2e/test-utils.ts
 
+      - name: Pull docker images
+        uses: ./.github/actions/retry-with-backoff
+        env:
+          IMAGE_TAGS: ${{ needs.build-images-tests.outputs.docker-tags }}
+        with:
+          command: docker compose -f ./xtm-hub-dev/docker-compose-ci.yml pull --include-deps e2e
+
       - name: Launch docker compose
         run: |
           mkdir -p ctrf
@@ -226,7 +233,6 @@ jobs:
            GITHUB_PR_NUMBER="${{ github.event.pull_request.number }}" \
            GITHUB_RUN_ID="${{ github.run_id }}" \
            PLAYWRIGHT_SHARD="${{ matrix.shard }}/8"
-          docker compose -f ./xtm-hub-dev/docker-compose-ci.yml pull --include-deps e2e
           docker compose -f ./xtm-hub-dev/docker-compose-ci.yml run \
            -e PLAYWRIGHT_SHARD \
            e2e sh -lc "yarn test:e2e --shard=${PLAYWRIGHT_SHARD}" || TEST_EXIT_CODE=$?
@@ -319,6 +325,11 @@ jobs:
       - name: Install docker
         uses: docker/setup-docker-action@v5
 
+      - name: Pull docker image
+        uses: ./.github/actions/retry-with-backoff
+        with:
+          command: docker pull filigran/portal-front-test:${{ needs.build-images-tests.outputs.docker-tags }}
+
       - name: Run front unit tests
         run: |
           export IMAGE_TAGS="${{ needs.build-images-tests.outputs.docker-tags }}" \
@@ -365,6 +376,13 @@ jobs:
 
       - name: Install docker
         uses: docker/setup-docker-action@v5
+
+      - name: Pull docker images
+        uses: ./.github/actions/retry-with-backoff
+        env:
+          IMAGE_TAGS: ${{ needs.build-images-tests.outputs.docker-tags }}
+        with:
+          command: docker compose -f ./xtm-hub-dev/docker-compose-ci.yml pull --include-deps backend-test
 
       - name: Run backend type-check
         if: matrix.shard == 1
@@ -481,25 +499,14 @@ jobs:
           echo "deployment_key=$DEPLOYMENT_KEY" >> "$GITHUB_OUTPUT"
 
       - name: Deploy
-        run: |
-          max_attempts=5
-          for i in $(seq 1 $max_attempts); do
-            if awx --conf.host https://awx.filigran.io \
+        uses: ./.github/actions/retry-with-backoff
+        with:
+          command: |
+            awx --conf.host https://awx.filigran.io \
               --conf.token ${{ secrets.AWX_TOKEN }} \
               -f human job_templates launch 'Deploy XTM Hub feature branch for testing' \
               --inventory eu-west-staging \
-              --extra_vars "{\"env\":\"Development\",\"xtmhub_version\":\"pr-${{ github.event.number }}\",\"xtmhub_node_env\":\"development\"}"; then
-              echo "✅ Deployment successful"
-              exit 0
-            fi
-            if [ $i -lt $max_attempts ]; then
-              delay=$((2 ** i))
-              echo "⚠️ Attempt $i/$max_attempts failed, retrying in ${delay}s..."
-              sleep $delay
-            fi
-          done
-          echo "❌ All $max_attempts attempts failed"
-          exit 1
+              --extra_vars "{\"env\":\"Development\",\"xtmhub_version\":\"pr-${{ github.event.number }}\",\"xtmhub_node_env\":\"development\"}"
 
   build-images-prod:
     needs:
@@ -646,26 +653,15 @@ jobs:
       - name: Deploy on Production
         id: awx_production_deploy
         if: contains(github.ref, 'refs/tags/')
-        run: |
-          export VERSION=$(echo "${GITHUB_REF_NAME}" | sed 's/^v//')
-          max_attempts=5
-          for i in $(seq 1 $max_attempts); do
-            if awx --conf.host https://awx.filigran.io \
+        uses: ./.github/actions/retry-with-backoff
+        with:
+          command: |
+            export VERSION=$(echo "${GITHUB_REF_NAME}" | sed 's/^v//')
+            awx --conf.host https://awx.filigran.io \
               --conf.token ${{ secrets.AWX_TOKEN }} \
               -f human job_templates launch 'Deploy XTM Hub' \
               --inventory eu-west-production \
-              --extra_vars "{\"env\":\"Production\",\"xtmhub_version\":\"$VERSION\"}"; then
-              echo "✅ Deployment successful"
-              exit 0
-            fi
-            if [ $i -lt $max_attempts ]; then
-              delay=$((2 ** i))
-              echo "⚠️ Attempt $i/$max_attempts failed, retrying in ${delay}s..."
-              sleep $delay
-            fi
-          done
-          echo "❌ All $max_attempts attempts failed"
-          exit 1
+              --extra_vars "{\"env\":\"Production\",\"xtmhub_version\":\"$VERSION\"}"
 
       - name: Send n8n Webhook Notification
         if: contains(github.ref, 'refs/tags/')
@@ -753,47 +749,25 @@ jobs:
 
       - name: Deploy on Development
         if: github.ref == 'refs/heads/main'
-        run: |
-          max_attempts=5
-          for i in $(seq 1 $max_attempts); do
-            if awx --conf.host https://awx.filigran.io \
+        uses: ./.github/actions/retry-with-backoff
+        with:
+          command: |
+            awx --conf.host https://awx.filigran.io \
               --conf.token ${{ secrets.AWX_TOKEN }} \
               -f human job_templates launch 'Deploy XTM Hub' \
               --inventory eu-west-staging \
-              --extra_vars '{"env":"Development"}'; then
-              echo "✅ Deployment successful"
-              exit 0
-            fi
-            if [ $i -lt $max_attempts ]; then
-              delay=$((2 ** i))
-              echo "⚠️ Attempt $i/$max_attempts failed, retrying in ${delay}s..."
-              sleep $delay
-            fi
-          done
-          echo "❌ All $max_attempts attempts failed"
-          exit 1
+              --extra_vars '{"env":"Development"}'
 
       - name: Deploy on Prerelease
         if: github.ref == 'refs/heads/main'
-        run: |
-          max_attempts=5
-          for i in $(seq 1 $max_attempts); do
-            if awx --conf.host https://awx.filigran.io \
+        uses: ./.github/actions/retry-with-backoff
+        with:
+          command: |
+            awx --conf.host https://awx.filigran.io \
               --conf.token ${{ secrets.AWX_TOKEN }} \
               -f human job_templates launch 'Deploy XTM Hub' \
               --inventory eu-west-staging \
-              --extra_vars '{"env":"Prerelease"}'; then
-              echo "✅ Deployment successful"
-              exit 0
-            fi
-            if [ $i -lt $max_attempts ]; then
-              delay=$((2 ** i))
-              echo "⚠️ Attempt $i/$max_attempts failed, retrying in ${delay}s..."
-              sleep $delay
-            fi
-          done
-          echo "❌ All $max_attempts attempts failed"
-          exit 1
+              --extra_vars '{"env":"Prerelease"}'
 
   # Notifies the team channel when CI fails on a protected branch (main/development)
   # or in the merge queue. Regular PR-branch CI failures are intentionally excluded,


### PR DESCRIPTION
# Context
> Briefly describe the purpose and context of this PR. Include relevant screenshots or screen recordings for the product team.
>
> ℹ️ **Feature environment** — A dedicated preview environment (`https://dev-pr-{number}.hub.staging.filigran.io`) is automatically deployed when CI passes. Add the `skip-feature-env` label to opt out.

Fixes intermittent CI failures caused by transient Docker Hub connection resets during image pulls in sharded test jobs (e.g. `failed to fetch oauth token: ... read: connection reset by peer` when pulling `postgres:17.2-alpine`).

Root cause: we already authenticate to Docker Hub via `docker/login-action`, but with 8 parallel shards each pulling images independently at the same time, transient Docker Hub connection resets during the pull's OAuth token exchange are more likely to occur and were not retried.

## Changes

- Added a reusable composite action `.github/actions/retry-with-backoff` that runs a given shell `command` with exponential backoff (`max-attempts` default 5, `initial-delay-seconds` default 2, doubling each retry).
- Wrapped Docker image pull steps with the new action in:
  - `run-e2e-tests-shards` (`docker compose pull --include-deps e2e`)
  - `run-api-unit-tests-shards` (`docker compose pull --include-deps backend-test`)
  - `run-front-unit-tests-shards` (`docker pull filigran/portal-front-test`)
- Refactored the existing AWX deploy retry loops (previously duplicated inline `for` loops with exponential backoff) to reuse the same composite action:
  - Feature-branch deploy
  - Production deploy
  - Development deploy
  - Prerelease deploy

## How to test
> Provide step-by-step instructions to test your changes. Include screenshots of your local testing results.

## Related issues

- Related to #3388

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [x] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [x] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Local manual tests

# Additional information
> Any additional context, dependencies, or concerns reviewers should know about.