### PR TITLE
chore(infra): replace the MinIO image by pgsty/silo in the dev/CI stacks and the Helm chart (#3400)

### DIFF
--- a/.github/agents/backend-code-writer.agent.md
+++ b/.github/agents/backend-code-writer.agent.md
@@ -28,7 +28,7 @@ performance bottlenecks and security weaknesses before delivering it.
 
 ## API / Integration Test Authoring
 As a senior backend integration test engineer, design robust, maintainable integration tests focused on real-world data flows:
-- Prefer real database calls over mocks for all `*.domain.ts` files. Only use mocks for external services (e.g., MinIO, Elasticsearch) or when testing `*.app.ts` files, and only when necessary.
+- Prefer real database calls over mocks for all `*.domain.ts` files. Only use mocks for external services (e.g., Silo / S3, Elasticsearch) or when testing `*.app.ts` files, and only when necessary.
 - Use the actual test DB for integration tests and clean up data between tests to ensure isolation; keep tests deterministic and independent of external state.
 - Do not manipulate the DB directly; use helper functions.
 - Use the project's constants and helpers for test data (e.g., from `tests/tests.const`).

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -4,7 +4,7 @@ applyTo: 'apps/backend/**'
 
 # Backend Instructions (`apps/backend`)
 
-Express 5 + Apollo Server + GraphQL + Knex + PostgreSQL + Elasticsearch + MinIO. Dev port **4002**.
+Express 5 + Apollo Server + GraphQL + Knex + PostgreSQL + Elasticsearch + Silo (S3). Dev port **4002**.
 
 ## Commands
 
@@ -23,7 +23,7 @@ Run from `apps/backend` (or `yarn workspace @xtm-hub/backend <script>`).
 
 Prefer the narrowest command that covers your change. Use `yarn test:ci` before opening a pull request.
 
-Tests need PostgreSQL and MinIO running (`docker compose -f xtm-hub-dev/docker-compose.yml up`). Vitest runs with
+Tests need PostgreSQL and Silo (S3) running (`docker compose -f xtm-hub-dev/docker-compose.yml up`). Vitest runs with
 `fileParallelism: false` and hits a real `test_database` when `VITEST_MODE=true`.
 
 ## Layout

--- a/.github/instructions/ci.instructions.md
+++ b/.github/instructions/ci.instructions.md
@@ -89,7 +89,7 @@ be installed explicitly.
 docker compose -f xtm-hub-dev/docker-compose.yml up
 ```
 
-PostgreSQL 5434, MinIO 9002, Elasticsearch 9204, Kibana 5603, PgAdmin 8888, Mailpit 8025/1025. Keep these ports in
+PostgreSQL 5434, Silo (S3) 9002, Elasticsearch 9204, Kibana 5603, PgAdmin 8888, Mailpit 8025/1025. Keep these ports in
 sync with `apps/backend/config/default.json` when changing either side.
 
 ## Deployment

--- a/.github/workflows/dockerbuild-ci.yml
+++ b/.github/workflows/dockerbuild-ci.yml
@@ -262,7 +262,7 @@ jobs:
           echo "=== PostgreSQL Logs ==="
           docker compose -f ./xtm-hub-dev/docker-compose-ci.yml logs --tail=100 portal-postgres || echo "Could not collect portal-postgres logs"
           echo ""
-          echo "=== MinIO Logs ==="
+          echo "=== Silo (S3) Logs ==="
           docker compose -f ./xtm-hub-dev/docker-compose-ci.yml logs --tail=100 portal-minio || echo "Could not collect portal-minio logs"
           echo ""
           echo "=== E2E Tests Logs ==="

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ workspaces.
 
 | Workspace | Path | Stack | Dev port |
 | --- | --- | --- | --- |
-| `@xtm-hub/backend` | `apps/backend` | Express 5, Apollo Server, GraphQL, Knex, PostgreSQL, Elasticsearch, MinIO | 4002 |
+| `@xtm-hub/backend` | `apps/backend` | Express 5, Apollo Server, GraphQL, Knex, PostgreSQL, Elasticsearch, Silo (S3) | 4002 |
 | `@xtm-hub/frontend` | `apps/frontend` | Next.js 16 (App Router + Turbopack), React 19, `@tanstack/react-query` (mandatory for new data fetching) + Relay (existing pages, being phased out), TailwindCSS 4, `@filigran/ui` | 3002 |
 | `@xtm-hub/test_e2e` | `apps/e2e` | Playwright | — |
 
@@ -30,7 +30,7 @@ per workspace.
 ## Development
 
 ```bash
-docker compose -f xtm-hub-dev/docker-compose.yml up   # PostgreSQL, MinIO, Elasticsearch, Kibana, PgAdmin, Mailpit
+docker compose -f xtm-hub-dev/docker-compose.yml up   # PostgreSQL, Silo (S3), Elasticsearch, Kibana, PgAdmin, Mailpit
 yarn dev:api                                          # backend on :4002
 yarn dev:front                                        # frontend on :3002 (start the API first)
 ```
@@ -44,7 +44,7 @@ yarn workspace @xtm-hub/backend  test:ci   # check-ts + lint + tests
 yarn workspace @xtm-hub/frontend test:ci   # lint + tests
 ```
 
-Backend tests need PostgreSQL and MinIO running, target `test_database` via `VITEST_MODE=true`, and execute with
+Backend tests need PostgreSQL and Silo (S3) running, target `test_database` via `VITEST_MODE=true`, and execute with
 `fileParallelism: false`. E2E tests need the frontend and backend already running.
 
 Only run linters, builds and tests that already exist; do not add new tooling unless the task requires it.

--- a/bruno/manifest/GetLatestManifestStorageDown.bru
+++ b/bruno/manifest/GetLatestManifestStorageDown.bru
@@ -16,7 +16,7 @@ assert {
 }
 
 docs {
-  Storage failure case. Requires a manifest row in database and MinIO stopped:
+  Storage failure case. Requires a manifest row in database and the Silo (S3) container stopped:
 
     podman ps --format '{{Names}}'
     podman stop <minio-container>

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: xtmhub
 description: A Helm chart for XTM-Hub
 type: application
-version: 0.1.7
+version: 0.1.8

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -85,8 +85,8 @@ postgres:
     password: "CHANGEME--q5Y6NbtbeIu3qyjk0iPthl2hCUkAmB--CHANGEME"
 minio:
   image:
-    repository: quay.io/minio/minio
-    tag: RELEASE.2025-06-13T11-33-47Z
+    repository: pgsty/silo
+    tag: latest
     pullPolicy: IfNotPresent
   ingressWhitelistSourceRange: "149.88.28.168/32,10.0.0.0/8"
   resources:

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -97,7 +97,7 @@ docker compose -f ./xtm-hub-dev/docker-compose.yml up
 
 This starts:
 - **PostgreSQL** on port `5434`
-- **MinIO** on port `9002` (console on `8902`)
+- **Silo** (S3 object storage, MinIO fork) on port `9002` (console on `8902`)
 - **PgAdmin** on port `8888`
 - **Elasticsearch** on port `9204`
 - **Kibana** on port `5603`
@@ -125,7 +125,7 @@ Once everything is running:
 
 - **Frontend**: http://localhost:3002
 - **API**: http://localhost:4002
-- **MinIO Console**: http://localhost:8902
+- **Silo Console**: http://localhost:8902
 - **PgAdmin**: http://localhost:8888 (portal@filigran.io / portal-password)
 - **Kibana**: http://localhost:5603
 - **Mailpit**: http://localhost:8025
@@ -241,7 +241,7 @@ yarn test:e2e
 1. **Port conflicts**: Ensure ports 3002, 4002, 5434, 5603, 8025, 8888, 9002, 8902, 9204, 1025 are available
 2. **Docker issues**: Verify the Docker daemon is running and `docker compose` is available
 3. **Yarn version mismatch**: Always run `corepack enable` first; the global/npm Yarn will not work
-4. **MinIO credentials**: Ensure `accessKeyId` and `secretAccessKey` in `local.json` match `docker-compose.yml`
+4. **Silo (S3) credentials**: Ensure `accessKeyId` and `secretAccessKey` in `local.json` match `docker-compose.yml`
 
 ### Reset development environment
 

--- a/xtm-hub-dev/docker-compose-ci.yml
+++ b/xtm-hub-dev/docker-compose-ci.yml
@@ -155,7 +155,7 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    image: "minio/minio:RELEASE.2025-06-13T11-33-47Z"
+    image: "pgsty/silo:latest"
     environment:
       MINIO_ROOT_USER: portal
       MINIO_ROOT_PASSWORD: changeme

--- a/xtm-hub-dev/docker-compose.yml
+++ b/xtm-hub-dev/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - pgadmin-data:/var/lib/pgadmin
 
   portal-minio:
-    image: "minio/minio:RELEASE.2025-06-13T11-33-47Z"
+    image: "pgsty/silo:latest"
     environment:
       MINIO_ROOT_USER: portal
       MINIO_ROOT_PASSWORD: changeme


### PR DESCRIPTION
# Context

The `minio/minio` image can no longer be pulled: the upstream MinIO repository was archived on 24 April 2026 (the community edition is now source-only), and Docker Hub has since removed the `minio/minio` and `minio/mc` repositories altogether - every tag answers 404 and `docker pull` fails with `pull access denied for minio/minio`. Every fresh deployment or CI run of a stack that still references these images is broken today.

Following OpenCTI-Platform/opencti#18239, the stack moves to [Silo](https://github.com/pgsty/silo), the community-maintained fork of the MinIO server published by Pigsty (`pgsty/silo` on Docker Hub, amd64 and arm64). Silo keeps the S3 API, the `MINIO_*` variables, the `server /data --console-address` command, the `/minio/health/live` route, the bundled `mc` client (so `mc ready local` healthchecks keep working) and the on-disk format unchanged, so an existing data volume is reused as is.

The `latest` tag is used on purpose: the MinIO-style dated release tags are not tracked anymore, and the whole Filigran ecosystem is aligned on `pgsty/silo:latest` (and `pgsty/mc:latest` for the client).

- `xtm-hub-dev/docker-compose.yml` and `xtm-hub-dev/docker-compose-ci.yml`: `portal-minio` runs `pgsty/silo:latest` instead of `minio/minio:RELEASE.2025-06-13T11-33-47Z` (no longer pullable, which breaks the CI e2e stack). Service name, ports (9002 / 8902), `portal` / `changeme` credentials, `minio server /data/minio` command (Silo's entrypoint translates the legacy `minio` command name to `silo`) and `mc ready local` healthcheck are untouched, so the backend S3 configuration keeps working as it is.
- `chart/values.yaml`: `minio.image` points at `pgsty/silo` / `latest` instead of the frozen `quay.io/minio/minio` release; `chart/Chart.yaml` bumped to 0.1.8, as for the previous MinIO bump (#971). The tenant is still run by the MinIO operator (`minio.min.io/v2` Tenant), which only needs the image's `server` entrypoint and the `/minio/health/live` route, both kept by Silo - please validate on staging before rolling out to production.
- Documentation and agent instructions (`docs/docs/getting-started.md`, `AGENTS.md`, `.github/instructions/*`, the CI log label, the Bruno request note) now name Silo where they named MinIO as the object storage of the stack.

## How to test

1. `docker compose -f xtm-hub-dev/docker-compose.yml up -d portal-minio` then `docker compose -f xtm-hub-dev/docker-compose.yml ps`: the container is `healthy`, the console answers on http://localhost:8902 (portal / changeme).
2. Run the backend tests (`VITEST_MODE=true`) against the dev stack, or start the backend and upload a document: it lands in the bucket exactly as before. The CI e2e jobs on this PR run against the new image.
3. `helm template xtmhub chart` renders `image: "pgsty/silo:latest"` on the Tenant.

Verified locally with Docker 29.6 on `pgsty/silo:RELEASE.2026-09-03T13-18-01Z` (the current `latest`) with the exact compose settings of the stack: the container reaches `healthy` through `mc ready local`, `/minio/health/live` and the console on 9001 answer 200, and a bucket create / upload / read round trip works with `pgsty/mc`. The image ships `/usr/bin/mc`, `/usr/bin/mcli` and `/usr/bin/curl`, so both healthcheck styles used across the Filigran stacks are supported.

## Related issues

- Closes #3400
- Same change across the ecosystem: OpenCTI-Platform/opencti#18239, FiligranHQ/xtm-docker#44, XTM-One-Platform/xtm-one#3531, OpenAEV-Platform/openaev#7928, OpenCTI-Platform/docker#607, OpenAEV-Platform/docker#163

# Checklist

## Quality

- [x] I consider this work complete and ready for review
- [x] I tested all features and edge cases
- [ ] I refactored code where necessary to improve quality
- [x] I made sure my code meets development guidelines
- [x] I performed a self-review of my code
- [ ] I added the `skip-feature-env` label if a feature environment is not needed for this PR

## Testing

- [ ] I wrote test cases for the relevant use cases (unit, integration or e2e tests)
- [ ] (Bug fixes only) I added tests that reproduce and verify the fix

### What tests have been made

- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [x] Local manual tests

# Additional information

The `latest` tag is used on purpose: the dated MinIO-style release tags are not tracked anymore and the whole Filigran ecosystem is aligned on `pgsty/silo:latest`. An existing `minio` data volume is reused as is (same on-disk format). Renovate ignores `chart/**` and the compose files, so nothing changes there.